### PR TITLE
Additional public fields

### DIFF
--- a/src/four_sect_dict.rs
+++ b/src/four_sect_dict.rs
@@ -39,9 +39,13 @@ pub struct FourSectDict {
 /// Designates one of the four sections.
 #[derive(Debug)]
 pub enum SectKind {
+    /// section for terms that appear as both subject and object
     Shared,
+    /// section for terms that only appear as subjects
     Subject,
+    /// section for terms that only appear as predicates
     Predicate,
+    /// sections for terms that only appear as objects
     Object,
 }
 
@@ -112,6 +116,7 @@ impl FourSectDict {
         }
     }
 
+    /// read the whole dictionary section including control information
     pub fn read<R: BufRead>(reader: &mut R) -> Result<UnvalidatedFourSectDict> {
         let dict_ci = ControlInfo::read(reader)?;
         if dict_ci.format != "<http://purl.org/HDT/hdt#dictionaryFour>" {
@@ -142,6 +147,7 @@ impl FourSectDict {
             .collect()
     }
     */
+    /// size in bytes of the in memory four section dictionary
     pub fn size_in_bytes(&self) -> usize {
         self.shared.size_in_bytes()
             + self.subjects.size_in_bytes()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ fn query(hdt: Hdt)
 /// Types for storing and reading data.
 pub mod containers;
 // Types for representing dictionaries.
-mod dict_sect_pfc;
+pub mod dict_sect_pfc;
 /// Types for representing a four section dictionary
 pub mod four_sect_dict;
 /// Types for representing triple sections.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,8 @@ fn query(hdt: Hdt)
 pub mod containers;
 // Types for representing dictionaries.
 mod dict_sect_pfc;
-mod four_sect_dict;
+/// Types for representing a four section dictionary
+pub mod four_sect_dict;
 /// Types for representing triple sections.
 pub mod hdt;
 #[cfg(feature = "sophia")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ fn query(hdt: Hdt)
 #![allow(clippy::multiple_crate_versions)]
 /// Types for storing and reading data.
 pub mod containers;
-// Types for representing dictionaries.
+/// Types for representing dictionaries.
 pub mod dict_sect_pfc;
 /// Types for representing a four section dictionary
 pub mod four_sect_dict;

--- a/src/triples.rs
+++ b/src/triples.rs
@@ -28,9 +28,10 @@ use serde::ser::SerializeStruct;
 /// Only SPO is tested, others probably don't work correctly.
 #[allow(missing_docs)]
 #[repr(u8)]
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "cache", derive(serde::Deserialize, serde::Serialize))]
 pub enum Order {
+    #[default]
     Unknown = 0,
     SPO = 1,
     SOP = 2,


### PR DESCRIPTION
follow-up to my comment about investigating the C++ code base more [here](https://github.com/KonradHoeffner/hdt/issues/49#issuecomment-2648074891)

I have a first pass working Rust rdf2hdt library and I want to re-use as much of this HDT library as possible.

- make a few more fields public
- add missing docs
- add a `save` function for ControlInfo

Still determining if any of the other structs are reusable - in which case I may add another `save` function - but I wanted to see if you were open to any of these changes first

@KonradHoeffner I can grant you access to the WIP repo I have if you're curious and want an early preview before I eventually publish the crate