### PR TITLE
dictionary needs to be able to save when there are no entries in the shared section

### DIFF
--- a/src/containers/sequence.rs
+++ b/src/containers/sequence.rs
@@ -214,8 +214,6 @@ impl Sequence {
     }
 
     fn pack_bits(&self) -> Vec<u8> {
-        assert!(self.bits_per_entry > 0 && self.bits_per_entry <= std::mem::size_of::<usize>() * 8);
-
         let mut output = Vec::new();
         let mut current_byte = 0u8;
         let mut bit_offset = 0;


### PR DESCRIPTION
I am working on incorporating the w3c [rdf-tests TTL samples files](https://github.com/w3c/rdf-tests/tree/main/sparql/sparql10) to ensure the covnerter handles known rdf syntaxes similar to what was done in the `oxhdt-sys` 
I incorporated into my initial upstream oxigraph PR https://github.com/oxigraph/oxigraph/pull/1211/commits/40a3467e8c2163c261084bef48c5e14b1214cf46 

While running those files through the converter, found a bug when one of the 4 section dictionaries did not have any entries (shared specifically) using https://github.com/w3c/rdf-tests/blob/main/sparql/sparql10/basic/data-3.ttl as an example. I can't remember if the assert was needed originally and became unnecessary as I iterated the `pack_bits` function, or whether I was just being overly cautious - but the assert is apparently no longer needed and actually breaks for the edge case described above