### PR TITLE
integrate more of the experimental-rdf2hdt branch / PR

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/resources/rdf-tests"]
+	path = tests/resources/rdf-tests
+	url = https://github.com/w3c/rdf-tests.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,22 @@ keywords = ["rdf", "hdt", "compression", "file-format"]
 categories = ["compression", "filesystem", "parsing", "web-programming"]
 edition = "2024"
 rust-version = "1.85"
+default-run = "rdf2hdt"
+
+[[bin]]
+name = "rdf2hdt"
+path = "src/rdf2hdt/main.rs"
+bench = false
 
 [package.metadata."docs.rs"]
 all-features = true
 
 [dependencies]
 bytesize = "2"
+clap = { version = "4.5", features = ["derive","cargo"] }
+clap-verbosity-flag = { version = "3.0", default-features = false, features = ["log"] }
 crc = "3"
+env_logger = { version = "0.11", default-features = false }
 iref = "3"
 langtag = "0.4"
 ntriple = "0.1"
@@ -26,6 +35,10 @@ log = "0.4"
 mownstr = "0.3"
 bincode = { version = "2", optional = true, default-features = false, features = ["std", "serde"] }
 serde = { version = "1", optional = true, features = ["derive"] }
+oxrdf = "0.2"
+oxrdfio = "0.1"
+chrono = "0.4.40"
+tempfile = "3.19.1"
 
 [features]
 default = ["sophia"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,4 @@ criterion = { version = "0.6", default-features = false, features = ["cargo_benc
 iai = { git = "https://github.com/sigaloid/iai", rev = "d56a597" } # until https://github.com/bheisler/iai/pull/35 is merged
 color-eyre = "0.6"
 fs-err = "3.1.0"
+walkdir = "2.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ pub mod header;
 /// Types for representing and querying triples.
 pub mod triples;
 
-//pub mod rdf2hdt;
+pub mod rdf2hdt;
 
 pub use crate::hdt::Hdt;
 use containers::ControlInfo;

--- a/src/rdf2hdt/bitmap_triples.rs
+++ b/src/rdf2hdt/bitmap_triples.rs
@@ -119,7 +119,7 @@ impl BitmapTriplesBuilder {
         // bitmapZ->save(output);
         self.save_bitmap(&self.bitmap_z, dest_writer)?;
 
-        let num_bits = self.num_triples.ilog2() + 1;
+        let num_bits = if self.num_triples == 0 { 0 } else { self.num_triples.ilog2() + 1 };
         if num_bits > u8::MAX as u32 {
             panic!("bits_per_entry too large")
         }

--- a/src/rdf2hdt/bitmap_triples.rs
+++ b/src/rdf2hdt/bitmap_triples.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 #[derive(Default, Debug)]
-pub struct BitmapTriplesBuilder {
+struct BitmapTriplesBuilder {
     y_vec: Vec<u32>,
     z_vec: Vec<u32>,
     bitmap_y: Vec<bool>,

--- a/src/rdf2hdt/bitmap_triples.rs
+++ b/src/rdf2hdt/bitmap_triples.rs
@@ -113,7 +113,7 @@ impl BitmapTriplesBuilder {
             ..Default::default()
         };
         ci.properties.insert("order".to_string(), (self.order.clone() as u8).to_string());
-        ci.save(dest_writer)?;
+        ci.write(dest_writer)?;
         self.save_bitmap(&self.bitmap_y, dest_writer)?;
 
         // bitmapZ->save(output);

--- a/src/rdf2hdt/bitmap_triples.rs
+++ b/src/rdf2hdt/bitmap_triples.rs
@@ -1,0 +1,179 @@
+// Copyright (c) 2024-2025, Decisym, LLC
+
+use crate::{
+    containers::{self, ControlType, vbyte::encode_vbyte},
+    rdf2hdt::{
+        common::{byte_align_bitmap, save_u32_vec},
+        dictionary::EncodedTripleId,
+        vocab::HDT_TYPE_BITMAP,
+    },
+    triples::Order,
+};
+use log::debug;
+use std::{
+    cmp::Ordering,
+    error::Error,
+    fs::File,
+    io::{BufWriter, Write},
+};
+
+#[derive(Default, Debug)]
+pub struct BitmapTriplesBuilder {
+    y_vec: Vec<u32>,
+    z_vec: Vec<u32>,
+    bitmap_y: Vec<bool>,
+    bitmap_z: Vec<bool>,
+    pub order: Order,
+    num_triples: usize,
+}
+
+impl BitmapTriplesBuilder {
+    /// Creates a new BitmapTriples from a list of sorted RDF triples
+    pub fn load(mut triples: Vec<EncodedTripleId>) -> Result<Self, Box<dyn Error>> {
+        // libhdt/src/triples/BitmapTriples.cpp:load()
+        let timer = std::time::Instant::now();
+
+        sort_triples_spo(&mut triples);
+
+        let mut y_bitmap = Vec::new();
+        let mut z_bitmap = Vec::new();
+        let mut array_y = Vec::new();
+        let mut array_z = Vec::new();
+
+        let mut last_x: u32 = 0;
+        let mut last_y: u32 = 0;
+        let mut last_z: u32 = 0;
+        for (i, triple) in triples.iter().enumerate() {
+            let x = triple.subject;
+            let y = triple.predicate;
+            let z = triple.object;
+
+            if x == 0 || y == 0 || z == 0 {
+                panic!("triple IDs should never be zero")
+            }
+
+            if i == 0 {
+                array_y.push(y);
+                array_z.push(z);
+            } else if x != last_x {
+                if x != last_x + 1 {
+                    panic!("the subjects must be correlative.")
+                }
+
+                //x unchanged
+                y_bitmap.push(true);
+                array_y.push(y);
+
+                z_bitmap.push(true);
+                array_z.push(z);
+            } else if y != last_y {
+                if y < last_y {
+                    panic!("the predicates must be in increasing order.")
+                }
+
+                // y unchanged
+                y_bitmap.push(false);
+                array_y.push(y);
+
+                z_bitmap.push(true);
+                array_z.push(z);
+            } else {
+                if z < last_z {
+                    panic!("the objects must be in increasing order")
+                }
+
+                // z changed
+                z_bitmap.push(false);
+                array_z.push(z);
+            }
+
+            last_x = x;
+            last_y = y;
+            last_z = z;
+        }
+
+        y_bitmap.push(true);
+        z_bitmap.push(true);
+        debug!("BitmapTriples build time: {:?}", timer.elapsed());
+
+        Ok(BitmapTriplesBuilder {
+            bitmap_y: y_bitmap,
+            bitmap_z: z_bitmap,
+            y_vec: array_y,
+            z_vec: array_z,
+            order: Order::SPO,
+            num_triples: triples.len(),
+        })
+    }
+
+    pub fn save(&self, dest_writer: &mut BufWriter<File>) -> Result<(), Box<dyn Error>> {
+        let mut ci = containers::ControlInfo {
+            control_type: ControlType::Triples,
+            format: HDT_TYPE_BITMAP.to_string(),
+            ..Default::default()
+        };
+        ci.properties.insert("order".to_string(), (self.order.clone() as u8).to_string());
+        ci.save(dest_writer)?;
+        self.save_bitmap(&self.bitmap_y, dest_writer)?;
+
+        // bitmapZ->save(output);
+        self.save_bitmap(&self.bitmap_z, dest_writer)?;
+
+        let num_bits = self.num_triples.ilog2() + 1;
+        if num_bits > u8::MAX as u32 {
+            panic!("bits_per_entry too large")
+        }
+        // arrayY->save(output);
+        save_u32_vec(&self.y_vec, dest_writer, num_bits.try_into().unwrap())?;
+        // // libhdt/src/sequence/LogSequence2.cpp::save()
+        save_u32_vec(&self.z_vec, dest_writer, num_bits.try_into().unwrap())?;
+
+        Ok(())
+    }
+
+    fn save_bitmap(&self, v: &[bool], dest_writer: &mut BufWriter<File>) -> Result<(), Box<dyn Error>> {
+        // libhdt/src/bitsequence/BitSequence375.cpp::save()
+        let crc = crc::Crc::<u8>::new(&crc::CRC_8_SMBUS);
+        let mut hasher = crc.digest();
+        // type
+        let bitmap_type: [u8; 1] = [1];
+        let _ = dest_writer.write(&bitmap_type)?;
+        hasher.update(&bitmap_type);
+        // number of bits
+        let t = encode_vbyte(v.len());
+        let _ = dest_writer.write(&t)?;
+        hasher.update(&t);
+        // crc8 checksum
+        let checksum = hasher.finalize();
+        let _ = dest_writer.write(&checksum.to_le_bytes())?;
+
+        // write data
+        let crc = crc::Crc::<u32>::new(&crc::CRC_32_ISCSI);
+        let mut hasher = crc.digest();
+        let buf = byte_align_bitmap(v);
+        let _ = dest_writer.write(&buf)?;
+        hasher.update(&buf);
+        let checksum = hasher.finalize();
+        let _ = dest_writer.write(&checksum.to_le_bytes())?;
+        Ok(())
+    }
+}
+
+/// Function to sort a vector of Triples in SPO order
+fn sort_triples_spo(triples: &mut [EncodedTripleId]) {
+    triples.sort_by(spo_comparator);
+}
+
+fn spo_comparator(a: &EncodedTripleId, b: &EncodedTripleId) -> Ordering {
+    let subject_order = a.subject.cmp(&b.subject);
+    if subject_order != Ordering::Equal {
+        return subject_order;
+    }
+
+    let predicate_order = a.predicate.cmp(&b.predicate);
+    if predicate_order != Ordering::Equal {
+        return predicate_order;
+    }
+
+    a.object.cmp(&b.object)
+}

--- a/src/rdf2hdt/builder.rs
+++ b/src/rdf2hdt/builder.rs
@@ -1,0 +1,288 @@
+// Copyright (c) 2024-2025, Decisym, LLC
+
+use super::{bitmap_triples::BitmapTriplesBuilder, dictionary::FourSectDictBuilder};
+use crate::{
+    containers::{self, ControlType},
+    rdf2hdt::{rdf_reader::convert_to_nt, vocab::*},
+};
+use log::{debug, error};
+use oxrdf::{BlankNodeRef, Literal, NamedNodeRef, Triple, vocab::rdf};
+use std::{
+    collections::HashSet,
+    error::Error,
+    fs::File,
+    io::{BufWriter, Write},
+};
+
+#[derive(Clone, Debug)]
+pub struct Options {
+    pub block_size: usize,
+    pub order: String,
+}
+impl Default for Options {
+    fn default() -> Self {
+        Options { block_size: 16, order: "SPO".to_string() }
+    }
+}
+
+pub fn build_hdt(file_paths: Vec<String>, dest_file: &str, opts: Options) -> Result<ConvertedHDT, Box<dyn Error>> {
+    if file_paths.is_empty() {
+        error!("no files provided");
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "no files provided to convert").into());
+    }
+
+    let timer = std::time::Instant::now();
+    // TODO
+    // implement an RDF reader trait
+    // 1. for larger datasets, read from source files everytime since storing all triples in memory may OOM kill process
+    // 2. build Vec<Triple> in memory from source files
+    let nt_file = if file_paths.len() == 1 && file_paths[0].ends_with(".nt") {
+        file_paths[0].clone()
+    } else {
+        let tmp_file = tempfile::Builder::new().suffix(".nt").keep(true).tempfile()?;
+        convert_to_nt(file_paths, tmp_file.reopen()?)?;
+        tmp_file.path().to_str().unwrap().to_string()
+    };
+
+    let converted_hdt = ConvertedHDT::load(&nt_file, opts)?;
+    debug!("HDT build time: {:?}", timer.elapsed());
+
+    converted_hdt.save(dest_file)?;
+
+    debug!("Total execution time: {:?}", timer.elapsed());
+    Ok(converted_hdt)
+}
+
+impl ConvertedHDT {
+    fn load(nt_file: &str, opts: Options) -> Result<Self, Box<dyn Error>> {
+        let (dictionary, encoded_triples) = FourSectDictBuilder::load(nt_file, opts.clone())?;
+        let num_triples = encoded_triples.len();
+        let bmap_triples = BitmapTriplesBuilder::load(encoded_triples)?;
+
+        let mut converted_hdt =
+            ConvertedHDT { dict: dictionary, triples: bmap_triples, num_triples, ..Default::default() };
+        converted_hdt.build_header(nt_file, opts)?;
+
+        Ok(converted_hdt)
+    }
+
+    pub fn save(&self, dest_file: &str) -> Result<(), Box<dyn Error>> {
+        let timer = std::time::Instant::now();
+
+        let file = File::create(dest_file)?;
+        let mut dest_writer = BufWriter::new(file);
+
+        // libhdt/src/hdt/BasicHDT.cpp::saveToHDT
+        let ci = containers::ControlInfo {
+            control_type: ControlType::Global,
+            format: HDT_CONTAINER.to_string(),
+            ..Default::default()
+        };
+        ci.save(&mut dest_writer)?;
+
+        let mut ci = containers::ControlInfo {
+            control_type: ControlType::Header,
+            format: "ntriples".to_string(),
+            ..Default::default()
+        };
+        let mut graph: oxrdf::Graph = oxrdf::Graph::new();
+        for t in &self.header {
+            graph.insert(t);
+        }
+        let graph_string = graph.to_string();
+        ci.properties.insert("length".to_string(), graph_string.len().to_string());
+        ci.save(&mut dest_writer)?;
+        let _ = dest_writer.write(graph_string.as_bytes())?;
+
+        self.dict.save(&mut dest_writer)?;
+
+        self.triples.save(&mut dest_writer)?;
+        dest_writer.flush()?;
+        debug!("HDT file output time: {:?}", timer.elapsed());
+        Ok(())
+    }
+
+    fn build_header(&mut self, source_file: &str, opts: Options) -> Result<(), Box<dyn Error>> {
+        let mut header = HashSet::new();
+        // libhdt/src/hdt/BasicHDT.cpp::fillHeader()
+
+        // uint64_t origSize = header->getPropertyLong(statisticsNode.c_str(), HDTVocabulary::ORIGINAL_SIZE.c_str());
+
+        // header->clear();
+        let file_iri = format!("file://{}", std::path::Path::new(source_file).canonicalize()?.display());
+        let base_iri = NamedNodeRef::new(&file_iri)?;
+        // // BASE
+        // header->insert(baseUri, HDTVocabulary::RDF_TYPE, HDTVocabulary::HDT_DATASET);
+        header.insert(Triple::new(base_iri, rdf::TYPE, HDT_CONTAINER));
+
+        // // VOID
+        // header->insert(baseUri, HDTVocabulary::RDF_TYPE, HDTVocabulary::VOID_DATASET);
+        header.insert(Triple::new(base_iri, rdf::TYPE, VOID_DATASET));
+        // header->insert(baseUri, HDTVocabulary::VOID_TRIPLES, triples->getNumberOfElements());
+        header.insert(Triple::new(
+            base_iri,
+            VOID_TRIPLES,
+            Literal::new_simple_literal(self.num_triples.to_string()),
+        ));
+        // header->insert(baseUri, HDTVocabulary::VOID_PROPERTIES, dictionary->getNpredicates());
+        header.insert(Triple::new(
+            base_iri,
+            VOID_PROPERTIES,
+            Literal::new_simple_literal(self.dict.predicate_terms.len().to_string()),
+        ));
+        // header->insert(baseUri, HDTVocabulary::VOID_DISTINCT_SUBJECTS, dictionary->getNsubjects());
+        header.insert(Triple::new(
+            base_iri,
+            VOID_DISTINCT_SUBJECTS,
+            Literal::new_simple_literal(
+                (self.dict.subject_terms.len() + self.dict.shared_terms.len()).to_string(),
+            ),
+        ));
+        // header->insert(baseUri, HDTVocabulary::VOID_DISTINCT_OBJECTS, dictionary->getNobjects());
+        header.insert(Triple::new(
+            base_iri,
+            VOID_DISTINCT_OBJECTS,
+            Literal::new_simple_literal((self.dict.object_terms.len() + self.dict.shared_terms.len()).to_string()),
+        ));
+        // // TODO: Add more VOID Properties. E.g. void:classes
+
+        // // Structure
+        let stats_id = BlankNodeRef::new("statistics")?;
+        let pub_id = BlankNodeRef::new("publicationInformation")?;
+        let format_id = BlankNodeRef::new("format")?;
+        let dict_id = BlankNodeRef::new("dictionary")?;
+        let triples_id = BlankNodeRef::new("triples")?;
+        // header->insert(baseUri, HDTVocabulary::HDT_STATISTICAL_INFORMATION,	statisticsNode);
+        header.insert(Triple::new(base_iri, HDT_STATISTICAL_INFORMATION, stats_id));
+        // header->insert(baseUri, HDTVocabulary::HDT_PUBLICATION_INFORMATION,	publicationInfoNode);
+        header.insert(Triple::new(base_iri, HDT_STATISTICAL_INFORMATION, pub_id));
+        // header->insert(baseUri, HDTVocabulary::HDT_FORMAT_INFORMATION, formatNode);
+        header.insert(Triple::new(base_iri, HDT_FORMAT_INFORMATION, format_id));
+        // header->insert(formatNode, HDTVocabulary::HDT_DICTIONARY, dictNode);
+        header.insert(Triple::new(format_id, HDT_DICTIONARY, dict_id));
+        // header->insert(formatNode, HDTVocabulary::HDT_TRIPLES, triplesNode);
+        header.insert(Triple::new(format_id, HDT_TRIPLES, triples_id));
+
+        // DICTIONARY
+        // header.insert(rootNode, HDTVocabulary::DICTIONARY_NUMSHARED, getNshared());
+        header.insert(Triple::new(
+            dict_id,
+            HDT_DICT_SHARED_SO,
+            Literal::new_simple_literal(self.dict.shared_terms.len().to_string()),
+        ));
+        // header.insert(rootNode, HDTVocabulary::DICTIONARY_MAPPING, this->mapping);
+        header.insert(Triple::new(dict_id, HDT_DICT_MAPPING, Literal::new_simple_literal("1")));
+        // header.insert(rootNode, HDTVocabulary::DICTIONARY_SIZE_STRINGS, size());
+        header.insert(Triple::new(dict_id, HDT_DICT_SIZE_STRINGS, Literal::new_simple_literal("FIXME")));
+        // header.insert(rootNode, HDTVocabulary::DICTIONARY_BLOCK_SIZE, this->blocksize);
+        header.insert(Triple::new(
+            dict_id,
+            HDT_DICT_BLOCK_SIZE,
+            Literal::new_simple_literal(opts.block_size.to_string()), // TODO is this always 16?
+        ));
+
+        // TRIPLES
+        // header.insert(rootNode, HDTVocabulary::TRIPLES_TYPE, getType());
+        header.insert(Triple::new(triples_id, DC_TERMS_FORMAT, HDT_TYPE_BITMAP));
+        // header.insert(rootNode, HDTVocabulary::TRIPLES_NUM_TRIPLES, getNumberOfElements() );
+        header.insert(Triple::new(
+            triples_id,
+            HDT_NUM_TRIPLES,
+            Literal::new_simple_literal(self.num_triples.to_string()),
+        ));
+        // header.insert(rootNode, HDTVocabulary::TRIPLES_ORDER, getOrderStr(order) );
+        header.insert(Triple::new(triples_id, HDT_TRIPLES_ORDER, Literal::new_simple_literal(opts.order)));
+
+        // // Sizes
+        let meta = File::open(std::path::Path::new(source_file))?.metadata().unwrap();
+        // header->insert(statisticsNode, HDTVocabulary::ORIGINAL_SIZE, origSize);
+        header.insert(Triple::new(
+            stats_id,
+            HDT_ORIGINAL_SIZE,
+            Literal::new_simple_literal(meta.len().to_string()),
+        ));
+        // header->insert(statisticsNode, HDTVocabulary::HDT_SIZE, getDictionary()->size() + getTriples()->size());
+        header.insert(Triple::new(stats_id, HDT_SIZE, Literal::new_simple_literal("FIXME")));
+
+        // // Current time
+        // struct tm* today = localtime(&now);
+        // strftime(date, 40, "%Y-%m-%dT%H:%M:%S%z", today);
+        // header->insert(publicationInfoNode, HDTVocabulary::DUBLIN_CORE_ISSUED, date);
+        let now = chrono::Utc::now(); // Get current local datetime
+        let datetime_str = now.format("%Y-%m-%dT%H:%M:%S%z").to_string(); // Format as string
+        header.insert(Triple::new(pub_id, DC_TERMS_ISSUED, Literal::new_simple_literal(datetime_str)));
+
+        self.header = header;
+
+        Ok(())
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct ConvertedHDT {
+    pub dict: FourSectDictBuilder,
+    pub triples: BitmapTriplesBuilder,
+    header: HashSet<oxrdf::Triple>,
+    num_triples: usize,
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::{
+        fs::remove_file,
+        io::{BufReader, Read},
+        path::Path,
+    };
+
+    use crate::{Hdt, containers::ControlInfo, four_sect_dict, header::Header, triples};
+
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_build_hdt() {
+        let output_file = "test.hdt";
+        let _ = remove_file(output_file);
+
+        let res = build_hdt(vec!["tests/resources/apple.ttl".to_string()], output_file, Options::default());
+        assert!(res.is_ok());
+        let conv_hdt = res.unwrap();
+
+        let p = Path::new(output_file);
+        assert!(p.exists());
+        let source = std::fs::File::open(p).expect("failed to open hdt file");
+        let mut hdt_reader = BufReader::new(source);
+
+        let _ci = ControlInfo::read(&mut hdt_reader).expect("failed to read HDT control info");
+        let _h = Header::read(&mut hdt_reader).expect("failed to read HDT Header");
+
+        let unvalidated_dict =
+            four_sect_dict::FourSectDict::read(&mut hdt_reader).expect("failed to read dictionary");
+        let dict = unvalidated_dict.validate().expect("invalid 4 section dictionary");
+        assert_eq!(dict.objects.num_strings(), conv_hdt.dict.object_terms.len());
+        assert_eq!(dict.subjects.num_strings(), conv_hdt.dict.subject_terms.len());
+        assert_eq!(dict.predicates.num_strings(), conv_hdt.dict.predicate_terms.len());
+        assert_eq!(dict.shared.num_strings(), conv_hdt.dict.shared_terms.len());
+
+        let _triples = triples::TriplesBitmap::read_sect(&mut hdt_reader).expect("invalid bitmap triples");
+        let mut buffer = [0; 1024];
+        assert!(hdt_reader.read(&mut buffer).expect("failed to read") == 0);
+
+        let source = std::fs::File::open(p).expect("failed to open hdt file");
+        let hdt_reader = BufReader::new(source);
+        let h = Hdt::new(hdt_reader).expect("failed to load HDT file");
+        let t: Vec<(Arc<str>, Arc<str>, Arc<str>)> = h.triples().collect();
+        println!("{:?}", t);
+        assert_eq!(t.len(), 9);
+
+        // http://example.org/apple#Apple,http://example.org/apple#color,Red
+        let s = "http://example.org/apple#Apple";
+        let p = "http://example.org/apple#color";
+        let o = "\"Red\"";
+        let triple_vec = vec![(Arc::from(s), Arc::from(p), Arc::from(o))];
+
+        let res = h.triples_with_pattern(None, Some(p), Some(o)).collect::<Vec<_>>();
+        assert_eq!(triple_vec, res)
+    }
+}

--- a/src/rdf2hdt/builder.rs
+++ b/src/rdf2hdt/builder.rs
@@ -78,7 +78,7 @@ impl ConvertedHDT {
             format: HDT_CONTAINER.to_string(),
             ..Default::default()
         };
-        ci.save(&mut dest_writer)?;
+        ci.write(&mut dest_writer)?;
 
         let mut ci = containers::ControlInfo {
             control_type: ControlType::Header,
@@ -91,7 +91,7 @@ impl ConvertedHDT {
         }
         let graph_string = graph.to_string();
         ci.properties.insert("length".to_string(), graph_string.len().to_string());
-        ci.save(&mut dest_writer)?;
+        ci.write(&mut dest_writer)?;
         let _ = dest_writer.write(graph_string.as_bytes())?;
 
         self.dict.save(&mut dest_writer)?;

--- a/src/rdf2hdt/builder.rs
+++ b/src/rdf2hdt/builder.rs
@@ -1,9 +1,10 @@
 // Copyright (c) 2024-2025, Decisym, LLC
 
-use super::{bitmap_triples::BitmapTriplesBuilder, dictionary::FourSectDictBuilder};
+use super::dictionary::FourSectDictBuilder;
 use crate::{
     containers::{self, ControlType},
     rdf2hdt::{rdf_reader::convert_to_nt, vocab::*},
+    triples::TriplesBitmap,
 };
 use log::{debug, error};
 use oxrdf::{BlankNodeRef, Literal, NamedNodeRef, Triple, vocab::rdf};
@@ -57,7 +58,7 @@ impl ConvertedHDT {
     fn load(nt_file: &str, opts: Options) -> Result<Self, Box<dyn Error>> {
         let (dictionary, encoded_triples) = FourSectDictBuilder::load(nt_file, opts.clone())?;
         let num_triples = encoded_triples.len();
-        let bmap_triples = BitmapTriplesBuilder::load(encoded_triples)?;
+        let bmap_triples = TriplesBitmap::new(encoded_triples)?;
 
         let mut converted_hdt =
             ConvertedHDT { dict: dictionary, triples: bmap_triples, num_triples, ..Default::default() };
@@ -221,7 +222,7 @@ impl ConvertedHDT {
 #[derive(Default, Debug)]
 pub struct ConvertedHDT {
     pub dict: FourSectDictBuilder,
-    pub triples: BitmapTriplesBuilder,
+    pub triples: TriplesBitmap,
     header: HashSet<oxrdf::Triple>,
     num_triples: usize,
 }

--- a/src/rdf2hdt/builder.rs
+++ b/src/rdf2hdt/builder.rs
@@ -178,7 +178,7 @@ impl ConvertedHDT {
         header.insert(Triple::new(
             dict_id,
             HDT_DICT_BLOCK_SIZE,
-            Literal::new_simple_literal(opts.block_size.to_string()), // TODO is this always 16?
+            Literal::new_simple_literal(opts.block_size.to_string()),
         ));
 
         // TRIPLES

--- a/src/rdf2hdt/common.rs
+++ b/src/rdf2hdt/common.rs
@@ -41,8 +41,6 @@ pub fn save_u32_vec(ints: &[u32], dest_writer: &mut BufWriter<File>, num_bits: u
 
 // TODO duplicate of containers/sequence.rs::save()
 fn pack_bits(data: &[u32], bits_per_entry: u8) -> Vec<u8> {
-    assert!(bits_per_entry > 0 && bits_per_entry as usize <= std::mem::size_of::<usize>() * 8);
-
     let mut output = Vec::new();
     let mut current_byte = 0u8;
     let mut bit_offset = 0;

--- a/src/rdf2hdt/common.rs
+++ b/src/rdf2hdt/common.rs
@@ -1,0 +1,104 @@
+// Copyright (c) 2024-2025, Decisym, LLC
+
+use std::{
+    error::Error,
+    fs::File,
+    io::{BufWriter, Write},
+};
+
+use crate::containers::vbyte::encode_vbyte;
+
+pub fn save_u32_vec(ints: &[u32], dest_writer: &mut BufWriter<File>, num_bits: u8) -> Result<(), Box<dyn Error>> {
+    let crc = crc::Crc::<u8>::new(&crc::CRC_8_SMBUS);
+    let mut hasher = crc.digest();
+    // libhdt/src/sequence/LogSequence2.cpp::save()
+    // Write offsets using variable-length encoding
+    let seq_type: [u8; 1] = [1];
+    let _ = dest_writer.write(&seq_type)?;
+    hasher.update(&seq_type);
+    // Write numbits
+    let bits_per_entry: [u8; 1] = [num_bits];
+    let _ = dest_writer.write(&bits_per_entry)?;
+    hasher.update(&bits_per_entry);
+    // Write numentries
+    let buf = &encode_vbyte(ints.len());
+    let _ = dest_writer.write(buf)?;
+    hasher.update(buf);
+    let checksum = hasher.finalize();
+    let _ = dest_writer.write(&checksum.to_le_bytes())?;
+
+    // Write data
+    let crc = crc::Crc::<u32>::new(&crc::CRC_32_ISCSI);
+    let mut hasher = crc.digest();
+    let offset_data = pack_bits(ints, num_bits);
+    let _ = dest_writer.write(&offset_data)?;
+    hasher.update(&offset_data);
+    let checksum = hasher.finalize();
+    let _ = dest_writer.write(&checksum.to_le_bytes())?;
+
+    Ok(())
+}
+
+// TODO duplicate of containers/sequence.rs::save()
+fn pack_bits(data: &[u32], bits_per_entry: u8) -> Vec<u8> {
+    assert!(bits_per_entry > 0 && bits_per_entry as usize <= std::mem::size_of::<usize>() * 8);
+
+    let mut output = Vec::new();
+    let mut current_byte = 0u8;
+    let mut bit_offset = 0;
+
+    for &value in data {
+        let mut val = value & ((1 << bits_per_entry) - 1); // mask to get only relevant bits
+        let mut bits_left = bits_per_entry;
+
+        while bits_left > 0 {
+            let available = 8 - bit_offset;
+            let to_write = bits_left.min(available);
+
+            // Shift bits to align with current byte offset
+            current_byte |= ((val & ((1 << to_write) - 1)) as u8) << bit_offset;
+
+            bit_offset += to_write;
+            val >>= to_write;
+            bits_left -= to_write;
+
+            if bit_offset == 8 {
+                output.push(current_byte);
+                current_byte = 0;
+                bit_offset = 0;
+            }
+        }
+    }
+
+    // Push final byte if there's remaining bits
+    if bit_offset > 0 {
+        output.push(current_byte);
+    }
+
+    output
+}
+
+pub fn byte_align_bitmap(bits: &[bool]) -> Vec<u8> {
+    let mut byte = 0u8;
+    let mut bit_index = 0;
+    let mut byte_vec = Vec::new();
+
+    for &bit in bits {
+        if bit {
+            byte |= 1 << bit_index;
+        }
+        bit_index += 1;
+
+        if bit_index == 8 {
+            byte_vec.push(byte);
+            byte = 0;
+            bit_index = 0;
+        }
+    }
+
+    // If remaining bits exist, pad the last byte
+    if bit_index > 0 {
+        byte_vec.push(byte);
+    }
+    byte_vec
+}

--- a/src/rdf2hdt/dictionary.rs
+++ b/src/rdf2hdt/dictionary.rs
@@ -230,17 +230,16 @@ pub fn compress(set: &BTreeSet<String>, block_size: usize) -> Result<DictSectPFC
         if i % block_size == 0 {
             offsets.push(compressed_terms.len() as u32);
             compressed_terms.extend_from_slice(term.as_bytes());
-            // Every block stores a full term
         } else {
-            // need to be careful with non-ascii characters here
             let common_prefix_len = last_term.chars().zip(term.chars()).take_while(|(a, b)| a == b).count();
+
             let byte_offset = term.char_indices().nth(common_prefix_len).map(|(i, _)| i).unwrap_or(term.len());
+
             compressed_terms.extend_from_slice(&encode_vbyte(common_prefix_len));
             compressed_terms.extend_from_slice(term[byte_offset..].as_bytes());
-        };
+        }
 
         compressed_terms.push(0); // Null separator
-
         last_term = term;
     }
     offsets.push(compressed_terms.len() as u32);

--- a/src/rdf2hdt/dictionary.rs
+++ b/src/rdf2hdt/dictionary.rs
@@ -181,27 +181,27 @@ impl FourSectDictBuilder {
         };
         ci.properties.insert("mappings".to_string(), "1".to_string());
         ci.properties.insert("sizeStrings".to_string(), self.size_strings.to_string());
-        ci.save(dest_writer)?;
+        ci.write(dest_writer)?;
         //shared
         // let log_seq = LogSequence2::compress(&self.dict.shared_terms)?;
         // log_seq.save(&mut dest_writer)?;
         let pfc = compress(&self.shared_terms, self.options.block_size)?;
-        pfc.save(dest_writer)?;
+        pfc.write(dest_writer)?;
         //subjects
         // let log_seq: LogSequence2 = LogSequence2::compress(&self.dict.subject_terms)?;
         // log_seq.save(&mut dest_writer)?;
         let pfc = compress(&self.subject_terms, self.options.block_size)?;
-        pfc.save(dest_writer)?;
+        pfc.write(dest_writer)?;
         //predicates
         // let log_seq = LogSequence2::compress(&self.dict.predicate_terms)?;
         // log_seq.save(&mut dest_writer)?;
         let pfc = compress(&self.predicate_terms, self.options.block_size)?;
-        pfc.save(dest_writer)?;
+        pfc.write(dest_writer)?;
         //objects
         // let log_seq = LogSequence2::compress(&self.dict.object_terms)?;
         // log_seq.save(&mut dest_writer)?;
         let pfc = compress(&self.object_terms, self.options.block_size)?;
-        pfc.save(dest_writer)?;
+        pfc.write(dest_writer)?;
         Ok(())
     }
 }

--- a/src/rdf2hdt/dictionary.rs
+++ b/src/rdf2hdt/dictionary.rs
@@ -1,0 +1,261 @@
+// Copyright (c) 2024-2025, Decisym, LLC
+
+use log::{debug, error};
+use oxrdf::Term;
+use oxrdfio::RdfFormat::NTriples;
+use oxrdfio::RdfParser;
+use std::{
+    collections::{BTreeSet, HashMap, HashSet},
+    error::Error,
+    fs::File,
+    io::{BufReader, BufWriter},
+    sync::Arc,
+};
+
+use crate::{
+    containers::{self, ControlType, Sequence, vbyte::encode_vbyte},
+    dict_sect_pfc::DictSectPFC,
+};
+
+use super::{builder::Options, vocab::HDT_DICTIONARY_TYPE_FOUR};
+
+#[derive(Default, Debug)]
+pub struct FourSectDictBuilder {
+    so_id_map: HashMap<String, u32>,
+    pred_id_map: HashMap<String, u32>,
+    subject_id_map: HashMap<String, u32>,
+    object_id_map: HashMap<String, u32>,
+
+    pub shared_terms: BTreeSet<String>,
+    pub subject_terms: BTreeSet<String>,
+    pub object_terms: BTreeSet<String>,
+    pub predicate_terms: BTreeSet<String>,
+
+    pub size_strings: usize,
+    options: Options,
+}
+
+#[derive(PartialEq)]
+enum DictionaryRole {
+    Subject,
+    Predicate,
+    Object,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct EncodedTripleId {
+    pub subject: u32,
+    pub predicate: u32,
+    pub object: u32,
+}
+
+impl FourSectDictBuilder {
+    // fn number_of_elements(&self) -> usize {
+    //     self.so_terms.len()
+    //         + self.subject_terms.len()
+    //         + self.predicate_terms.len()
+    //         + self.object_terms.len()
+    // }
+
+    pub fn load(nt_file: &str, opts: Options) -> Result<(Self, Vec<EncodedTripleId>), Box<dyn Error>> {
+        let source = match std::fs::File::open(nt_file) {
+            Ok(f) => f,
+            Err(e) => {
+                error!("Error opening file {:?}: {:?}", nt_file, e);
+                return Err(e.into());
+            }
+        };
+        let source_reader = BufReader::new(source);
+        // use Hashset on triples to remove duplicates
+        let mut triples = HashSet::new();
+        let quads = RdfParser::from_format(NTriples).for_reader(source_reader);
+        let timer = std::time::Instant::now();
+
+        // TODO: compare times with Vec followed by parallel sort vs times with BTreeSet
+        let mut subject_terms = BTreeSet::new();
+        let mut object_terms = BTreeSet::new();
+        let mut dict = FourSectDictBuilder { options: opts, ..Default::default() };
+        for q in quads {
+            let q = q?; //propagate the error  
+
+            subject_terms.insert(term_to_hdt_bgp_str(&q.subject.into())?);
+            dict.predicate_terms.insert(term_to_hdt_bgp_str(&q.predicate.into())?);
+            object_terms.insert(term_to_hdt_bgp_str(&q.object)?);
+        }
+
+        dict.shared_terms = subject_terms.intersection(&object_terms).cloned().collect();
+        dict.subject_terms = subject_terms.difference(&dict.shared_terms).cloned().collect();
+        dict.object_terms = object_terms.difference(&dict.shared_terms).cloned().collect();
+
+        /*
+        https://www.w3.org/submissions/2011/SUBM-HDT-20110330/#dictionaryEncoding
+        Four subsets are mapped as follows (for a graph G with SG, PG, OG the different subjects, predicates and objects):
+        1. Common subject-objects (SOG) with IDs from 1 to |SOG|
+        2. Non common subjects (SG-SOG), mapped to [|SOG| +1, |SG|]
+        3. Non common objects (OG-SOG), in [|SOG|+1, |OG|]
+        4. Predicates, mapped to [1, |PG|].
+         */
+
+        // Shared subject-objects: 1..=|SOG|
+        let mut shared_id = 1;
+        for term in &dict.shared_terms {
+            dict.so_id_map.insert(term.clone(), shared_id);
+            shared_id += 1;
+        }
+
+        // TODO run these 3 dictionary builds in parallel?
+
+        // Subject-only: |SOG|+1 ..= |SG|
+        let mut id = shared_id;
+        for term in &dict.subject_terms {
+            dict.subject_id_map.insert(term.clone(), id);
+            id += 1;
+        }
+
+        // Object-only: |SOG|+1 ..= |OG|
+        let mut id = shared_id;
+        for term in &dict.object_terms {
+            dict.object_id_map.insert(term.clone(), id);
+            id += 1;
+        }
+
+        // Predicates: 1..=|PG|
+        for (i, term) in dict.predicate_terms.iter().enumerate() {
+            dict.pred_id_map.insert(term.clone(), (i + 1) as u32);
+        }
+        debug!("Four Section Dictions sort time: {:?}", timer.elapsed());
+
+        let source = match std::fs::File::open(nt_file) {
+            Ok(f) => f,
+            Err(e) => {
+                error!("Error opening file {:?}: {:?}", nt_file, e);
+                return Err(e.into());
+            }
+        };
+        let triple_encoder_timer = std::time::Instant::now();
+        let source_reader = BufReader::new(source);
+        let quads = RdfParser::from_format(NTriples).for_reader(source_reader);
+        for q in quads {
+            let q = q?; //propagate the error  
+            triples.insert(EncodedTripleId {
+                subject: dict.term_to_id(&term_to_hdt_bgp_str(&q.subject.into())?, DictionaryRole::Subject),
+                predicate: dict.term_to_id(&term_to_hdt_bgp_str(&q.predicate.into())?, DictionaryRole::Predicate),
+                object: dict.term_to_id(&term_to_hdt_bgp_str(&q.object)?, DictionaryRole::Object),
+            });
+        }
+        debug!("Encoding triples time: {:?}", triple_encoder_timer.elapsed());
+        debug!("Dictionary build time: {:?}", timer.elapsed());
+        // println!("triples: {:?}", triples);
+        Ok((dict, triples.into_iter().collect()))
+    }
+
+    fn term_to_id(&self, term: &str, role: DictionaryRole) -> u32 {
+        match role {
+            DictionaryRole::Predicate => *self.pred_id_map.get(term).unwrap(),
+            DictionaryRole::Subject => {
+                if let Some(id) = self.so_id_map.get(term) {
+                    *id
+                } else {
+                    *self.subject_id_map.get(term).unwrap()
+                }
+            }
+            DictionaryRole::Object => {
+                if let Some(id) = self.so_id_map.get(term) {
+                    *id
+                } else {
+                    *self.object_id_map.get(term).unwrap()
+                }
+            }
+        }
+    }
+
+    pub fn save(&self, dest_writer: &mut BufWriter<File>) -> Result<(), Box<dyn Error>> {
+        // libhdt/src/dictionary/FourSectionDictionary.cpp::save()
+        let mut ci = containers::ControlInfo {
+            control_type: ControlType::Dictionary,
+            format: HDT_DICTIONARY_TYPE_FOUR.to_string(),
+            ..Default::default()
+        };
+        ci.properties.insert("mappings".to_string(), "1".to_string());
+        ci.properties.insert("sizeStrings".to_string(), self.size_strings.to_string());
+        ci.save(dest_writer)?;
+        //shared
+        // let log_seq = LogSequence2::compress(&self.dict.shared_terms)?;
+        // log_seq.save(&mut dest_writer)?;
+        let pfc = compress(&self.shared_terms, self.options.block_size)?;
+        pfc.save(dest_writer)?;
+        //subjects
+        // let log_seq: LogSequence2 = LogSequence2::compress(&self.dict.subject_terms)?;
+        // log_seq.save(&mut dest_writer)?;
+        let pfc = compress(&self.subject_terms, self.options.block_size)?;
+        pfc.save(dest_writer)?;
+        //predicates
+        // let log_seq = LogSequence2::compress(&self.dict.predicate_terms)?;
+        // log_seq.save(&mut dest_writer)?;
+        let pfc = compress(&self.predicate_terms, self.options.block_size)?;
+        pfc.save(dest_writer)?;
+        //objects
+        // let log_seq = LogSequence2::compress(&self.dict.object_terms)?;
+        // log_seq.save(&mut dest_writer)?;
+        let pfc = compress(&self.object_terms, self.options.block_size)?;
+        pfc.save(dest_writer)?;
+        Ok(())
+    }
+}
+
+/// Convert triple string formats from OxRDF to HDT.
+fn term_to_hdt_bgp_str(term: &Term) -> Result<String, Box<dyn Error>> {
+    let hdt_str = match term {
+        // hdt terms should not include < >'s from IRIs
+        Term::NamedNode(named_node) => named_node.clone().into_string(),
+
+        Term::Literal(literal) => literal.to_string(),
+
+        Term::BlankNode(_s) => term.to_string(),
+    };
+
+    Ok(hdt_str)
+}
+
+pub fn compress(set: &BTreeSet<String>, block_size: usize) -> Result<DictSectPFC, Box<dyn Error>> {
+    let mut terms: Vec<String> = set.iter().to_owned().cloned().collect();
+    terms.sort(); // Ensure lexicographic order
+    // println!("{:?}", terms);
+    let mut compressed_terms = Vec::new();
+    let mut offsets = Vec::new();
+    let mut last_term = "";
+
+    let num_terms = terms.len();
+    for (i, term) in terms.iter().enumerate() {
+        if i % block_size == 0 {
+            offsets.push(compressed_terms.len() as u32);
+            compressed_terms.extend_from_slice(term.as_bytes());
+            // Every block stores a full term
+        } else {
+            let common_prefix_len = last_term.chars().zip(term.chars()).take_while(|(a, b)| a == b).count();
+            compressed_terms.extend_from_slice(&encode_vbyte(common_prefix_len));
+            compressed_terms.extend_from_slice(term[common_prefix_len..].as_bytes());
+        };
+
+        compressed_terms.push(0); // Null separator
+
+        last_term = term;
+    }
+    offsets.push(compressed_terms.len() as u32);
+
+    // offsets are an increasing list of array indices, therefore the last one will be the largest
+    // potential off by 1 in comparison with hdt-cpp implementation
+    let bits_per_entry = (offsets.last().unwrap().ilog2() + 1) as usize;
+
+    Ok(DictSectPFC {
+        num_strings: num_terms,
+        block_size,
+        sequence: Sequence {
+            entries: offsets.len(),
+            bits_per_entry,
+            data: offsets.iter().map(|v| *v as usize).collect(),
+            crc_handle: None,
+        },
+        packed_data: Arc::from(compressed_terms),
+    })
+}

--- a/src/rdf2hdt/main.rs
+++ b/src/rdf2hdt/main.rs
@@ -26,7 +26,7 @@
 //! This will take `data.ttl`, convert to NTriple, and generate and save the HDT output to `result.hdt`.
 
 use clap::{Parser, Subcommand};
-use hdt::rdf2hdt::builder::{build_hdt, Options};
+use hdt::rdf2hdt::builder::{Options, build_hdt};
 
 /// Command-line interface for rdf2hdt Converter
 ///
@@ -76,26 +76,15 @@ enum Commands {
 fn main() {
     let cli = Cli::parse();
 
-    env_logger::Builder::new()
-        .filter_level(cli.verbose.log_level_filter())
-        .init();
+    env_logger::Builder::new().filter_level(cli.verbose.log_level_filter()).init();
 
     match &cli.command {
-        Some(Commands::Convert {
-            input,
-            output,
-            block_size,
-        }) => match build_hdt(
-            input.clone(),
-            output,
-            Options {
-                block_size: *block_size,
-                order: "SPO".to_string()
-            },
-        ) {
-            Ok(_) => {}
-            Err(e) => eprintln!("Error writing: {}", e),
-        },
+        Some(Commands::Convert { input, output, block_size }) => {
+            match build_hdt(input.clone(), output, Options { block_size: *block_size, order: "SPO".to_string() }) {
+                Ok(_) => {}
+                Err(e) => eprintln!("Error writing: {}", e),
+            }
+        }
         None => {}
     }
 }

--- a/src/rdf2hdt/main.rs
+++ b/src/rdf2hdt/main.rs
@@ -1,0 +1,101 @@
+// Copyright (c) 2024-2025, Decisym, LLC
+
+//! # rdf2hdt Converter
+//!
+//! This is a Rust-based tool that converts RDF data into HDT format. It uses the `oxrdfio` crate
+//! for RDF parsing and conversion, and then generates and saves the data as HDT.
+//! Implementation is based on the [HDT specification](https://www.w3.org/submissions/2011/SUBM-HDT-20110330)
+//! and the output HDT is intended to be consumed by one of [hdt crate](https://github.com/KonradHoeffner/hdt),
+//! [hdt-cpp](https://github.com/rdfhdt/hdt-cpp), or [hdt-java](https://github.com/rdfhdt/hdt-java).
+//!
+//! ## Features
+//! - Parses RDF input and converts it to RDF triples
+//! - Convert NTriple data into HDT format
+//!
+//! ## Usage
+//! Run the rdf2hdt converter from the command line. For detailed usage information, run:
+//! ```
+//! rdf2hdt --help
+//! ```
+//!
+//! ## Example
+//! To convert a RDF file to HDT format and write to the specified output file:
+//! ```
+//! rdf2hdt convert --input data.ttl --output result.hdt
+//! ```
+//! This will take `data.ttl`, convert to NTriple, and generate and save the HDT output to `result.hdt`.
+
+use clap::{Parser, Subcommand};
+use hdt::rdf2hdt::builder::{build_hdt, Options};
+
+/// Command-line interface for rdf2hdt Converter
+///
+/// This struct defines the command-line interface (CLI) for interacting with the rdf2hdt converter.
+#[derive(Parser)]
+#[command(version, about = "Converts RDF data into HDT format.")]
+struct Cli {
+    /// CLI command selection
+    #[command(subcommand)]
+    command: Option<Commands>,
+    #[command(flatten)]
+    verbose: clap_verbosity_flag::Verbosity,
+}
+
+/// Supported Commands
+///
+/// Contains the available commands for the rdf2hdt converter.
+#[derive(Subcommand)]
+enum Commands {
+    /// Convert RDF to HDT.
+    ///
+    /// The `convert` command parses RDF files, converts it to RDF triples using `oxrdfio` for parsing
+    /// and conversion, and then generates and saves the data as HDT.
+    Convert {
+        /// Path to input RDF file(s).
+        ///
+        /// Provide the path to one or more RDF files that will be parsed and converted.
+        /// Support file formats: https://crates.io/crates/oxrdfio
+        #[arg(short, long, num_args = 1..)]
+        input: Vec<String>,
+
+        /// Path to output file.
+        ///
+        /// Specify the path to save the generated HDT.
+        #[arg(short, long)]
+        output: String,
+
+        /// Block size used during term compression
+        ///
+        /// Every Nth term will be stored fully while others will only contain everything besides the
+        /// longest common prefix of the last Nth term
+        #[arg(short, long, default_value_t = 16)]
+        block_size: usize,
+    },
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    env_logger::Builder::new()
+        .filter_level(cli.verbose.log_level_filter())
+        .init();
+
+    match &cli.command {
+        Some(Commands::Convert {
+            input,
+            output,
+            block_size,
+        }) => match build_hdt(
+            input.clone(),
+            output,
+            Options {
+                block_size: *block_size,
+                order: "SPO".to_string()
+            },
+        ) {
+            Ok(_) => {}
+            Err(e) => eprintln!("Error writing: {}", e),
+        },
+        None => {}
+    }
+}

--- a/src/rdf2hdt/mod.rs
+++ b/src/rdf2hdt/mod.rs
@@ -1,8 +1,7 @@
-
 pub mod builder;
 
 mod bitmap_triples;
 mod common;
-mod rdf_reader;
 mod dictionary;
+mod rdf_reader;
 mod vocab;

--- a/src/rdf2hdt/mod.rs
+++ b/src/rdf2hdt/mod.rs
@@ -1,0 +1,8 @@
+
+pub mod builder;
+
+mod bitmap_triples;
+mod common;
+mod rdf_reader;
+mod dictionary;
+mod vocab;

--- a/src/rdf2hdt/rdf_reader.rs
+++ b/src/rdf2hdt/rdf_reader.rs
@@ -1,0 +1,107 @@
+// Copyright (c) 2024-2025, Decisym, LLC
+
+use log::{debug, error, warn};
+use oxrdfio::RdfSerializer;
+use oxrdfio::{
+    RdfFormat::{self, NTriples},
+    RdfParseError, RdfParser,
+};
+use std::io::Write;
+use std::{
+    error::Error,
+    io::{BufReader, BufWriter},
+    path::Path,
+};
+
+pub fn convert_to_nt(
+    file_paths: Vec<String>,
+    output_file: std::fs::File,
+) -> Result<(), Box<dyn Error>> {
+    let mut dest_writer = BufWriter::new(output_file);
+    for file in file_paths {
+        let source = match std::fs::File::open(&file) {
+            Ok(f) => f,
+            Err(e) => {
+                error!("Error opening file {:?}: {:?}", file, e);
+                return Err(e.into());
+            }
+        };
+        let source_reader = BufReader::new(source);
+
+        debug!("converting {} to nt format", &file);
+
+        let mut serializer = RdfSerializer::from_format(NTriples).for_writer(dest_writer.by_ref());
+        let v = std::time::Instant::now();
+        let rdf_format = if let Some(t) =
+            RdfFormat::from_extension(Path::new(&file).extension().unwrap().to_str().unwrap())
+        {
+            t
+        } else {
+            error!("unrecognized file extension for {file}");
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("unrecognized file extension for {file}"),
+            )
+            .into());
+        };
+        let quads = RdfParser::from_format(rdf_format).for_reader(source_reader);
+        let mut warned = false;
+        for q in quads {
+            let q = match q {
+                Ok(v) => v,
+                Err(e) => {
+                    match e {
+                        RdfParseError::Io(v) => {
+                            // I/O error while reading file
+                            error!("Error reading file {file}: {v}");
+                            return Err(v.into());
+                        }
+                        RdfParseError::Syntax(syn_err) => {
+                            error!("syntax error for RDF file {file}: {syn_err}");
+                            return Err(syn_err.into());
+                        }
+                    }
+                }
+            };
+            if !warned && q.graph_name != oxrdf::GraphName::DefaultGraph {
+                warned = true;
+                warn!("HDT does not support named graphs, merging triples for {file}");
+            }
+            serializer.serialize_triple(oxrdf::TripleRef {
+                subject: q.subject.as_ref(),
+                predicate: q.predicate.as_ref(),
+                object: q.object.as_ref(),
+            })?
+        }
+
+        serializer.finish()?;
+        debug!("RDF to NTriple convert time: {:?}", v.elapsed());
+    }
+    dest_writer.flush()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_rdf() {
+        let tmp_file = tempfile::Builder::new().suffix(".nt").tempfile().expect("");
+        assert!(
+            (convert_to_nt(
+                vec!["tests/resources/apple.ttl".to_string()],
+                tmp_file.reopen().expect("error opening tmp file")
+            ))
+            .is_ok()
+        );
+        let source_reader = BufReader::new(tmp_file.reopen().expect("error opening tmp file"));
+        let quads = RdfParser::from_format(NTriples)
+            .for_reader(source_reader)
+            .collect::<Result<Vec<_>, _>>();
+
+        assert!(quads.is_ok());
+        assert_eq!(quads.unwrap().len(), 9)
+    }
+}

--- a/src/rdf2hdt/rdf_reader.rs
+++ b/src/rdf2hdt/rdf_reader.rs
@@ -13,7 +13,10 @@ use std::{
     path::Path,
 };
 
-pub fn convert_to_nt(file_paths: Vec<String>, output_file: std::fs::File) -> Result<(), Box<dyn Error>> {
+pub fn convert_to_nt(
+    file_paths: Vec<String>,
+    output_file: std::fs::File,
+) -> Result<(), Box<dyn Error>> {
     let mut dest_writer = BufWriter::new(output_file);
     for file in file_paths {
         let source = match std::fs::File::open(&file) {
@@ -29,17 +32,18 @@ pub fn convert_to_nt(file_paths: Vec<String>, output_file: std::fs::File) -> Res
 
         let mut serializer = RdfSerializer::from_format(NTriples).for_writer(dest_writer.by_ref());
         let v = std::time::Instant::now();
-        let rdf_format =
-            if let Some(t) = RdfFormat::from_extension(Path::new(&file).extension().unwrap().to_str().unwrap()) {
-                t
-            } else {
-                error!("unrecognized file extension for {file}");
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("unrecognized file extension for {file}"),
-                )
-                .into());
-            };
+        let rdf_format = if let Some(t) =
+            RdfFormat::from_extension(Path::new(&file).extension().unwrap().to_str().unwrap())
+        {
+            t
+        } else {
+            error!("unrecognized file extension for {file}");
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("unrecognized file extension for {file}"),
+            )
+            .into());
+        };
         let quads = RdfParser::from_format(rdf_format).for_reader(source_reader);
         let mut warned = false;
         for q in quads {
@@ -93,7 +97,9 @@ mod tests {
             .is_ok()
         );
         let source_reader = BufReader::new(tmp_file.reopen().expect("error opening tmp file"));
-        let quads = RdfParser::from_format(NTriples).for_reader(source_reader).collect::<Result<Vec<_>, _>>();
+        let quads = RdfParser::from_format(NTriples)
+            .for_reader(source_reader)
+            .collect::<Result<Vec<_>, _>>();
 
         assert!(quads.is_ok());
         assert_eq!(quads.unwrap().len(), 9)

--- a/src/rdf2hdt/rdf_reader.rs
+++ b/src/rdf2hdt/rdf_reader.rs
@@ -13,10 +13,7 @@ use std::{
     path::Path,
 };
 
-pub fn convert_to_nt(
-    file_paths: Vec<String>,
-    output_file: std::fs::File,
-) -> Result<(), Box<dyn Error>> {
+pub fn convert_to_nt(file_paths: Vec<String>, output_file: std::fs::File) -> Result<(), Box<dyn Error>> {
     let mut dest_writer = BufWriter::new(output_file);
     for file in file_paths {
         let source = match std::fs::File::open(&file) {
@@ -32,19 +29,20 @@ pub fn convert_to_nt(
 
         let mut serializer = RdfSerializer::from_format(NTriples).for_writer(dest_writer.by_ref());
         let v = std::time::Instant::now();
-        let rdf_format = if let Some(t) =
-            RdfFormat::from_extension(Path::new(&file).extension().unwrap().to_str().unwrap())
-        {
-            t
-        } else {
-            error!("unrecognized file extension for {file}");
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("unrecognized file extension for {file}"),
-            )
-            .into());
-        };
-        let quads = RdfParser::from_format(rdf_format).for_reader(source_reader);
+        let rdf_format =
+            if let Some(t) = RdfFormat::from_extension(Path::new(&file).extension().unwrap().to_str().unwrap()) {
+                t
+            } else {
+                error!("unrecognized file extension for {file}");
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("unrecognized file extension for {file}"),
+                )
+                .into());
+            };
+        let quads = RdfParser::from_format(rdf_format)
+            .with_base_iri(format!("file://{}", Path::new(&file).file_name().unwrap().to_str().unwrap()))?
+            .for_reader(source_reader);
         let mut warned = false;
         for q in quads {
             let q = match q {
@@ -97,9 +95,7 @@ mod tests {
             .is_ok()
         );
         let source_reader = BufReader::new(tmp_file.reopen().expect("error opening tmp file"));
-        let quads = RdfParser::from_format(NTriples)
-            .for_reader(source_reader)
-            .collect::<Result<Vec<_>, _>>();
+        let quads = RdfParser::from_format(NTriples).for_reader(source_reader).collect::<Result<Vec<_>, _>>();
 
         assert!(quads.is_ok());
         assert_eq!(quads.unwrap().len(), 9)

--- a/src/rdf2hdt/rdf_reader.rs
+++ b/src/rdf2hdt/rdf_reader.rs
@@ -13,10 +13,7 @@ use std::{
     path::Path,
 };
 
-pub fn convert_to_nt(
-    file_paths: Vec<String>,
-    output_file: std::fs::File,
-) -> Result<(), Box<dyn Error>> {
+pub fn convert_to_nt(file_paths: Vec<String>, output_file: std::fs::File) -> Result<(), Box<dyn Error>> {
     let mut dest_writer = BufWriter::new(output_file);
     for file in file_paths {
         let source = match std::fs::File::open(&file) {
@@ -32,18 +29,17 @@ pub fn convert_to_nt(
 
         let mut serializer = RdfSerializer::from_format(NTriples).for_writer(dest_writer.by_ref());
         let v = std::time::Instant::now();
-        let rdf_format = if let Some(t) =
-            RdfFormat::from_extension(Path::new(&file).extension().unwrap().to_str().unwrap())
-        {
-            t
-        } else {
-            error!("unrecognized file extension for {file}");
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("unrecognized file extension for {file}"),
-            )
-            .into());
-        };
+        let rdf_format =
+            if let Some(t) = RdfFormat::from_extension(Path::new(&file).extension().unwrap().to_str().unwrap()) {
+                t
+            } else {
+                error!("unrecognized file extension for {file}");
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("unrecognized file extension for {file}"),
+                )
+                .into());
+            };
         let quads = RdfParser::from_format(rdf_format).for_reader(source_reader);
         let mut warned = false;
         for q in quads {
@@ -97,9 +93,7 @@ mod tests {
             .is_ok()
         );
         let source_reader = BufReader::new(tmp_file.reopen().expect("error opening tmp file"));
-        let quads = RdfParser::from_format(NTriples)
-            .for_reader(source_reader)
-            .collect::<Result<Vec<_>, _>>();
+        let quads = RdfParser::from_format(NTriples).for_reader(source_reader).collect::<Result<Vec<_>, _>>();
 
         assert!(quads.is_ok());
         assert_eq!(quads.unwrap().len(), 9)

--- a/src/rdf2hdt/vocab.rs
+++ b/src/rdf2hdt/vocab.rs
@@ -1,0 +1,50 @@
+// Copyright (c) 2024-2025, Decisym, LLC
+
+use oxrdf::NamedNodeRef;
+
+pub const HDT_CONTAINER: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#HDTv1");
+pub const VOID_TRIPLES: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://rdfs.org/ns/void#triples");
+pub const VOID_PROPERTIES: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://rdfs.org/ns/void#properties");
+pub const VOID_DISTINCT_SUBJECTS: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://rdfs.org/ns/void#distinctSubjects");
+pub const VOID_DISTINCT_OBJECTS: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://rdfs.org/ns/void#distinctObjects");
+pub const VOID_DATASET: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://rdfs.org/ns/void#Dataset");
+pub const HDT_STATISTICAL_INFORMATION: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#statisticalInformation");
+pub const HDT_PUBLICATION_INFORMATION: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#publicationInformation");
+pub const HDT_FORMAT_INFORMATION: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#formatInformation");
+pub const HDT_DICTIONARY: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#dictionary");
+pub const HDT_TRIPLES: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#triples");
+pub const DC_TERMS_FORMAT: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://purl.org/dc/terms/format");
+pub const HDT_NUM_TRIPLES: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#triplesnumTriples");
+pub const HDT_TRIPLES_ORDER: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#triplesOrder");
+pub const HDT_ORIGINAL_SIZE: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#originalSize");
+pub const HDT_SIZE: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#hdtSize");
+pub const DC_TERMS_ISSUED: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://purl.org/dc/terms/issued");
+pub const HDT_DICT_SHARED_SO: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#dictionarynumSharedSubjectObject");
+pub const HDT_DICT_MAPPING: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#dictionarymapping");
+pub const HDT_DICT_SIZE_STRINGS: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#dictionarysizeStrings");
+pub const HDT_DICT_BLOCK_SIZE: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#dictionaryblockSize");
+pub const HDT_TYPE_BITMAP: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#triplesBitmap");
+pub const HDT_DICTIONARY_TYPE_FOUR: NamedNodeRef<'_> =
+    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#dictionaryFour");

--- a/src/rdf2hdt/vocab.rs
+++ b/src/rdf2hdt/vocab.rs
@@ -2,40 +2,31 @@
 
 use oxrdf::NamedNodeRef;
 
-pub const HDT_CONTAINER: NamedNodeRef<'_> =
-    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#HDTv1");
-pub const VOID_TRIPLES: NamedNodeRef<'_> =
-    NamedNodeRef::new_unchecked("http://rdfs.org/ns/void#triples");
-pub const VOID_PROPERTIES: NamedNodeRef<'_> =
-    NamedNodeRef::new_unchecked("http://rdfs.org/ns/void#properties");
+pub const HDT_CONTAINER: NamedNodeRef<'_> = NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#HDTv1");
+pub const VOID_TRIPLES: NamedNodeRef<'_> = NamedNodeRef::new_unchecked("http://rdfs.org/ns/void#triples");
+pub const VOID_PROPERTIES: NamedNodeRef<'_> = NamedNodeRef::new_unchecked("http://rdfs.org/ns/void#properties");
 pub const VOID_DISTINCT_SUBJECTS: NamedNodeRef<'_> =
     NamedNodeRef::new_unchecked("http://rdfs.org/ns/void#distinctSubjects");
 pub const VOID_DISTINCT_OBJECTS: NamedNodeRef<'_> =
     NamedNodeRef::new_unchecked("http://rdfs.org/ns/void#distinctObjects");
-pub const VOID_DATASET: NamedNodeRef<'_> =
-    NamedNodeRef::new_unchecked("http://rdfs.org/ns/void#Dataset");
+pub const VOID_DATASET: NamedNodeRef<'_> = NamedNodeRef::new_unchecked("http://rdfs.org/ns/void#Dataset");
 pub const HDT_STATISTICAL_INFORMATION: NamedNodeRef<'_> =
     NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#statisticalInformation");
 pub const HDT_PUBLICATION_INFORMATION: NamedNodeRef<'_> =
     NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#publicationInformation");
 pub const HDT_FORMAT_INFORMATION: NamedNodeRef<'_> =
     NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#formatInformation");
-pub const HDT_DICTIONARY: NamedNodeRef<'_> =
-    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#dictionary");
-pub const HDT_TRIPLES: NamedNodeRef<'_> =
-    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#triples");
-pub const DC_TERMS_FORMAT: NamedNodeRef<'_> =
-    NamedNodeRef::new_unchecked("http://purl.org/dc/terms/format");
+pub const HDT_DICTIONARY: NamedNodeRef<'_> = NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#dictionary");
+pub const HDT_TRIPLES: NamedNodeRef<'_> = NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#triples");
+pub const DC_TERMS_FORMAT: NamedNodeRef<'_> = NamedNodeRef::new_unchecked("http://purl.org/dc/terms/format");
 pub const HDT_NUM_TRIPLES: NamedNodeRef<'_> =
     NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#triplesnumTriples");
 pub const HDT_TRIPLES_ORDER: NamedNodeRef<'_> =
     NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#triplesOrder");
 pub const HDT_ORIGINAL_SIZE: NamedNodeRef<'_> =
     NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#originalSize");
-pub const HDT_SIZE: NamedNodeRef<'_> =
-    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#hdtSize");
-pub const DC_TERMS_ISSUED: NamedNodeRef<'_> =
-    NamedNodeRef::new_unchecked("http://purl.org/dc/terms/issued");
+pub const HDT_SIZE: NamedNodeRef<'_> = NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#hdtSize");
+pub const DC_TERMS_ISSUED: NamedNodeRef<'_> = NamedNodeRef::new_unchecked("http://purl.org/dc/terms/issued");
 pub const HDT_DICT_SHARED_SO: NamedNodeRef<'_> =
     NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#dictionarynumSharedSubjectObject");
 pub const HDT_DICT_MAPPING: NamedNodeRef<'_> =
@@ -44,7 +35,6 @@ pub const HDT_DICT_SIZE_STRINGS: NamedNodeRef<'_> =
     NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#dictionarysizeStrings");
 pub const HDT_DICT_BLOCK_SIZE: NamedNodeRef<'_> =
     NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#dictionaryblockSize");
-pub const HDT_TYPE_BITMAP: NamedNodeRef<'_> =
-    NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#triplesBitmap");
+pub const HDT_TYPE_BITMAP: NamedNodeRef<'_> = NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#triplesBitmap");
 pub const HDT_DICTIONARY_TYPE_FOUR: NamedNodeRef<'_> =
     NamedNodeRef::new_unchecked("http://purl.org/HDT/hdt#dictionaryFour");

--- a/tests/resources/apple.ttl
+++ b/tests/resources/apple.ttl
@@ -1,0 +1,14 @@
+@prefix ex: <http://example.org/apple#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+
+ex:Apple rdf:type ex:Fruit;
+  rdfs:label "Apple";
+  ex:variety "Red Delicious";
+  ex:color "Red";
+  ex:weight "150 grams";
+  ex:origin "United States";
+  ex:isOrganic true.
+
+ex:Fruit rdf:type rdfs:Class;
+  rdfs:label "Fruit".

--- a/tests/resources/apple.ttl
+++ b/tests/resources/apple.ttl
@@ -3,12 +3,12 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 
 ex:Apple rdf:type ex:Fruit;
-  rdfs:label "Apple";
   ex:variety "Red Delicious";
   ex:color "Red";
   ex:weight "150 grams";
   ex:origin "United States";
-  ex:isOrganic true.
+  ex:isOrganic true;
+  rdfs:label "\u03BCApple".
 
 ex:Fruit rdf:type rdfs:Class;
   rdfs:label "Fruit".


### PR DESCRIPTION
The goal is to first identify, which other parts of PR #56 that aren't already integrated can be integrated into the parent crate in a multi-purpose way.
For example, right now the HDT library can only load an existing HDT "TriplesBitmap" but cannot create one from scratch.
PR #56 contains such functionality but I would like to move it into the existing structures where possible, as this could also help with other use cases, e.g. testing, and this would reduce code size.
Unfortunately this PR view compares it to main while it would be more interesting to see the changes on top of the PR as well.
Also this more general way might be a bit less performant in some cases like conversion because if we create e.g. a new TriplesBitmap then we always create the indexes as well, but for the specific use case of conversion those are never used and just discarded on save.