### PR TITLE
0.4.0-alpha fixes

### DIFF
--- a/src/containers/sequence.rs
+++ b/src/containers/sequence.rs
@@ -254,7 +254,7 @@ impl Sequence {
         use sucds::int_vectors::CompactVector;
         let entries = nums.len();
         if entries == 0 && bits_per_entry == 0 {
-            return Sequence{entries, bits_per_entry, data: vec![]}
+            return Sequence { entries, bits_per_entry, data: vec![] };
         }
         let mut cv = CompactVector::with_capacity(nums.len(), bits_per_entry).expect("value too large");
         cv.extend(nums.iter().copied()).unwrap();

--- a/src/containers/sequence.rs
+++ b/src/containers/sequence.rs
@@ -253,6 +253,9 @@ impl Sequence {
     pub fn new(nums: &[usize], bits_per_entry: usize) -> Sequence {
         use sucds::int_vectors::CompactVector;
         let entries = nums.len();
+        if entries == 0 && bits_per_entry == 0 {
+            return Sequence{entries, bits_per_entry, data: vec![]}
+        }
         let mut cv = CompactVector::with_capacity(nums.len(), bits_per_entry).expect("value too large");
         cv.extend(nums.iter().copied()).unwrap();
         let data = cv.into_bit_vector().into_words();

--- a/src/dict_sect_pfc.rs
+++ b/src/dict_sect_pfc.rs
@@ -345,7 +345,9 @@ impl DictSectPFC {
             compressed_terms.push(0); // Null separator
             last_term = term;
         }
-        offsets.push(compressed_terms.len());
+        if num_terms > 0 {
+            offsets.push(compressed_terms.len());
+        }
 
         // offsets are an increasing list of array indices, therefore the last one will be the largest
         // TODO: potential off by 1 in comparison with hdt-cpp implementation?

--- a/src/dict_sect_pfc.rs
+++ b/src/dict_sect_pfc.rs
@@ -490,6 +490,7 @@ mod tests {
             let items2 = sect_items(&sect2);
             assert_eq!(items1, items2, "error compressing {name} section");
         }
+        assert_eq!(0, DictSectPFC::compress(&BTreeSet::new(), BLOCK_SIZE).num_strings);
         Ok(())
     }
 }

--- a/src/hdt.rs
+++ b/src/hdt.rs
@@ -102,6 +102,11 @@ impl Hdt {
         let mut reader = std::io::BufReader::new(source);
         let (dict, mut encoded_triples) = FourSectDict::read_nt(&mut reader, BLOCK_SIZE)?;
         let num_triples = encoded_triples.len();
+        if num_triples == 0 {
+            use crate::triples;
+
+            return Err(Error::Triples(triples::Error::Empty));
+        }
         encoded_triples.sort_unstable();
         let triples = TriplesBitmap::from_triples(&encoded_triples);
 

--- a/src/hdt.rs
+++ b/src/hdt.rs
@@ -102,11 +102,6 @@ impl Hdt {
         let mut reader = std::io::BufReader::new(source);
         let (dict, mut encoded_triples) = FourSectDict::read_nt(&mut reader, BLOCK_SIZE)?;
         let num_triples = encoded_triples.len();
-        if num_triples == 0 {
-            use crate::triples;
-
-            return Err(Error::Triples(triples::Error::Empty));
-        }
         encoded_triples.sort_unstable();
         let triples = TriplesBitmap::from_triples(&encoded_triples);
 
@@ -488,6 +483,8 @@ pub mod tests {
         assert_eq!(nt_triples, hdt_triples);
         assert_eq!(snikmeta.triples.bitmap_y.dict, snikmeta_nt.triples.bitmap_y.dict);
         snikmeta_check(&snikmeta_nt)?;
+        let path = std::path::Path::new("tests/resources/empty.nt");
+        Hdt::read_nt(path)?;
         Ok(())
     }
 

--- a/src/triples.rs
+++ b/src/triples.rs
@@ -188,6 +188,8 @@ pub enum Error {
     TripleComponentZero(usize, usize, usize),
     #[error("unspecified external library error")]
     External(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error("no triples detected in source file")]
+    Empty,
     #[error("cache decode error")]
     #[cfg(feature = "cache")]
     Decode(#[from] bincode::error::DecodeError),


### PR DESCRIPTION
Cheery-pick of fixes found during expanded testing of the sparql feature using w3c rdf tests [here](https://github.com/KonradHoeffner/hdt/pull/83)

Included:
 - cases where shared dict.len() == 0
 - return a dedicated Error when no triples are detected rather than `panic!`