### PR TITLE
print pack_data len rather than entire array

### DIFF
--- a/src/dict_sect_pfc.rs
+++ b/src/dict_sect_pfc.rs
@@ -53,7 +53,7 @@ impl fmt::Debug for DictSectPFC {
             ByteSize(self.size_in_bytes() as u64),
             self.num_strings,
             self.sequence,
-            self.packed_data //ByteSize(self.packed_data.len() as u64)
+            ByteSize(self.packed_data.len() as u64)
         )
     }
 }


### PR DESCRIPTION
I think this was an accidental addition during debugging the rdf-to-hdt work.  Original formatter just output the packed_data length rather than the entire array. Results in large debug logs when working with larger HDT files