### PR TITLE
Minor 0.5.0 edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 A Rust library for the [Header Dictionary Triples](https://www.rdfhdt.org/) compressed RDF format, including:
 
-* loading the HDT default format as created by [hdt-cpp](https://github.com/rdfhdt/hdt-cpp)
+* loading the HDT default format as created by this library or [hdt-cpp](https://github.com/rdfhdt/hdt-cpp)
 * converting N-Triples to HDT
 * efficient querying by triple patterns
 * serializing into other formats like RDF Turtle and N-Triples using the [Sophia](https://crates.io/crates/sophia) adapter

--- a/src/hdt.rs
+++ b/src/hdt.rs
@@ -67,7 +67,7 @@ impl Hdt {
     }
 
     /// Creates an immutable HDT instance containing the dictionary and triples from the given reader.
-    /// The reader must point to the beginning of the data of an HDT file as produced by hdt-cpp.
+    /// The reader must point to the beginning of the data of an HDT file.
     /// FourSectionDictionary with DictionarySectionPlainFrontCoding and SPO order is the only supported implementation.
     /// The format is specified at <https://www.rdfhdt.org/hdt-binary-format/>, however there are some deviations.
     /// The initial HDT specification at <http://www.w3.org/Submission/2011/03/> is outdated and not supported.
@@ -99,7 +99,7 @@ impl Hdt {
 
     /// Creates an immutable HDT instance containing the dictionary and triples from the Path.
     /// Will utilize a custom cached TriplesBitmap file if exists or create one if it does not exist.
-    /// The file path must point to the beginning of the data of an HDT file as produced by hdt-cpp.
+    /// The file path must point to the beginning of the data of an HDT file.
     /// FourSectionDictionary with DictionarySectionPlainFrontCoding and SPO order is the only supported implementation.
     /// The format is specified at <https://www.rdfhdt.org/hdt-binary-format/>, however there are some deviations.
     /// The initial HDT specification at <http://www.w3.org/Submission/2011/03/> is outdated and not supported.
@@ -179,7 +179,9 @@ impl Hdt {
     }
 
     #[cfg(feature = "cache")]
-    fn write_cache(
+    /// Writes a custom cache file to improve load times. This cache file is usuable only by
+    /// this library and is not intended to be used with hdt-cpp or hdt-java versions of the HDT tooling
+    pub fn write_cache(
         index_file_path: &std::path::PathBuf, triples: &TriplesBitmap, header_length: usize,
     ) -> core::result::Result<(), Box<dyn std::error::Error>> {
         let new_index_file = File::create(index_file_path)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! HDT is a loading and triple pattern querying library for the [Header Dictionary Triples](https://www.rdfhdt.org/) compressed binary RDF format.
 //!
-//! Currently this library only supports loading and querying existing HDT files as created by [hdt-cpp](https://github.com/rdfhdt/hdt-cpp).
+//! Currently this library only supports loading and querying existing HDT files as created by this library or [hdt-cpp](https://github.com/rdfhdt/hdt-cpp).
 //! For reference implementations of HDT in C++ and Java, which support conversion and serialization from and into HDT with different format options,
 //! and acknowledgement of all the original authors, please look at the <https://github.com/rdfhdt> organisation.
 //!


### PR DESCRIPTION
 - Removes left over `info` log message from RDF-to-HDT conversion performance analysis. Could be left in, but missing labels for timings as-is
 - Makes `write_cache` public. In convert to HDT scenarios, RDF is read and converted to HDT, written to file, and then `read_from_path()` called to read into memory again in order to generate the cache. So it's done automatically on read, but no way to toggle the cache generation on the initial `write`
 - Updated README and documentation to remove requirement that HDT file must be on generated by hdt-cpp library