### PR TITLE
Max thread override

### DIFF
--- a/src/nt.rs
+++ b/src/nt.rs
@@ -165,6 +165,12 @@ fn read_dict_triples(path: &Path, block_size: usize) -> Result<(FourSectDict, Ve
 //pub fn parse_nt_terms(path: &Path) -> Result<(Vec<[usize; 3]>, Indices, Indices, Indices, Vec<String>)> {
 fn parse_nt_terms(path: &Path) -> Result<IndexPool> {
     let lasso: Arc<ThreadedRodeo<Spur>> = Arc::new(ThreadedRodeo::new());
+    // determine max parallel threads from MAX_THREADS env var or number of CPU cores
+    let max_threads = std::env::var("MAX_THREADS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or_else(|| thread::available_parallelism().map(|n| n.get()).unwrap_or(1));
+    debug!("Using up to {max_threads} threads for N-Triples parsing");
     // Store triple indices instead of strings
     let readers =
         NTriplesParser::new().split_file_for_parallel_parsing(path, thread::available_parallelism()?.get())?;

--- a/src/nt.rs
+++ b/src/nt.rs
@@ -161,15 +161,13 @@ fn read_dict_triples(path: &Path, block_size: usize) -> Result<(FourSectDict, Ve
     Ok((dict, encoded_triples))
 }
 
-/// Parse N-Triples and collect terms into sets
-/// use MAX_PARALLEL_PARSERS to cap the number of parallel parsers, oterwise defaults to number of CPU cores.
+/// Parse N-Triples in parallel and collect terms into sets
 fn parse_nt_terms(path: &Path) -> Result<IndexPool> {
     let lasso: Arc<ThreadedRodeo<Spur>> = Arc::new(ThreadedRodeo::new());
     // workaround for bug with lasso v0.7.3 when concurrency is too high, see https://github.com/Kixiron/lasso/issues/48
     // experiments have always failed with 24, often with 23 and sometimes with 22 threads, choose 16 to be on the safe side
     // use two threads when available parallelism cannot be determined as going to a single thread is around 38% slower
     let num_parsers = std::cmp::min(16, thread::available_parallelism().map(|n| n.get()).unwrap_or(2));
-    debug!("Using up to {num_parsers} parallel parsers for N-Triples");
     // Store triple indices instead of strings
     let readers = NTriplesParser::new().split_file_for_parallel_parsing(path, num_parsers)?;
     let triples: Vec<[usize; 3]> = readers

--- a/src/nt.rs
+++ b/src/nt.rs
@@ -165,14 +165,13 @@ fn read_dict_triples(path: &Path, block_size: usize) -> Result<(FourSectDict, Ve
 /// use MAX_PARALLEL_PARSERS to cap the number of parallel parsers, oterwise defaults to number of CPU cores.
 fn parse_nt_terms(path: &Path) -> Result<IndexPool> {
     let lasso: Arc<ThreadedRodeo<Spur>> = Arc::new(ThreadedRodeo::new());
-    // determine max parallel parsers from MAX_PARALLEL_PARSERS env var or number of CPU cores
-    let max_parsers = std::env::var("MAX_PARALLEL_PARSERS")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or_else(|| thread::available_parallelism().map(|n| n.get()).unwrap_or(1));
-    debug!("Using up to {max_parsers} parallel parsers for N-Triples");
+    // workaround for bug with lasso v0.7.3 when concurrency is too high, see https://github.com/Kixiron/lasso/issues/48
+    // experiments have always failed with 24, often with 23 and sometimes with 22 threads, choose 16 to be on the safe side
+    // use two threads when available parallelism cannot be determined as going to a single thread is around 38% slower
+    let num_parsers = std::cmp::min(16, thread::available_parallelism().map(|n| n.get()).unwrap_or(2));
+    debug!("Using up to {num_parsers} parallel parsers for N-Triples");
     // Store triple indices instead of strings
-    let readers = NTriplesParser::new().split_file_for_parallel_parsing(path, max_parsers)?;
+    let readers = NTriplesParser::new().split_file_for_parallel_parsing(path, num_parsers)?;
     let triples: Vec<[usize; 3]> = readers
         .into_par_iter()
         .flat_map_iter(|reader| {


### PR DESCRIPTION
Started using HPC environments again and ran into https://github.com/Kixiron/lasso/issues/48

The original reporter said they hit it going from 10 -> 64 CPU's, and on my HPC env I can get pretty high:
```bash
> nproc
256
```

Which frequently hits the reported race condition, crashing like so:
```
> ./target/release/hdt convert source.nt test.hdt
Using up to 256 threads for N-Triples parsing
The application panicked (crashed).
Message:  Failed to get or intern string: LassoError { kind: FailedAllocation }
Location: /p/home/gihanson/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lasso-0.7.3/src/threaded_rodeo.rs:290
The application panicked (crashed).
Message:  Failed to get or intern string: LassoError { kind: FailedAllocation }
Location: /p/home/gihanson/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lasso-0.7.3/src/threaded_rodeo.rs:290
The application panicked (crashed).
Message:  Failed to get or intern string: LassoError { kind: FailedAllocation }
Location: /p/home/gihanson/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lasso-0.7.3/src/threaded_rodeo.rs:290
The application panicked (crashed).
Message:  Failed to get or intern string: LassoError { kind: FailedAllocation }
Location: /p/home/gihanson/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lasso-0.7.3/src/threaded_rodeo.rs:290
The application panicked (crashed).
...
...
The application panicked (crashed).
Message:  Failed to get or intern string: LassoError { kind: FailedAllocation }
Location: /p/home/gihanson/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lasso-0.7.3/src/threaded_rodeo.rs:290

```
Definitely a race condition, as it does succeed sometimes. I am testing with a 36 million triple / ~5GB NT file, but haven't been able to say conclusively if it occurs more or less frequently as file size increases