### PR TITLE
Header metadata api

### DIFF
--- a/src/hdt.rs
+++ b/src/hdt.rs
@@ -442,7 +442,7 @@ pub mod tests {
         use crate::containers::rdf::{Id as RdfId, Term as RdfTerm, Triple as RdfTriple};
 
         init();
-        let mut hdt = Hdt::read_nt(Path::new("tests/resources/empty.nt"))?;
+        let mut hdt = Hdt::read_nt(std::path::Path::new("tests/resources/empty.nt"))?;
         let triple = RdfTriple::new(
             RdfId::Named("http://example.org/dataset".to_owned()),
             "https://decisym.ai/de#graphIRI".to_owned(),

--- a/src/hdt.rs
+++ b/src/hdt.rs
@@ -206,6 +206,32 @@ impl Hdt {
         self.dict.size_in_bytes() + self.triples.size_in_bytes()
     }
 
+    /// Returns the HDT header.
+    pub fn header(&self) -> &Header {
+        &self.header
+    }
+
+    /// Returns a mutable HDT header.
+    ///
+    /// Call [`Self::recompute_header_length`] after mutating header triples so the
+    /// serialized header control information stays consistent.
+    pub fn header_mut(&mut self) -> &mut Header {
+        &mut self.header
+    }
+
+    /// Recomputes the serialized byte length for the current header body.
+    ///
+    /// This should be called after mutating [`Self::header_mut`].
+    pub fn recompute_header_length(&mut self) -> std::io::Result<()> {
+        use std::io::Write as _;
+        let mut buf = Vec::<u8>::new();
+        for triple in &self.header.body {
+            writeln!(&mut buf, "{triple}")?;
+        }
+        self.header.length = buf.len();
+        Ok(())
+    }
+
     /// An iterator visiting *all* triples as strings in order.
     /// Using this method with a filter can be inefficient for large graphs,
     /// because the strings are stored in compressed form and must be decompressed and allocated.
@@ -407,6 +433,29 @@ pub mod tests {
         hdt.write(&mut buf)?;
         let hdt2 = Hdt::read(std::io::Cursor::new(buf))?;
         snikmeta_check(&hdt2)?;
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(feature = "nt")]
+    fn header_metadata_can_be_mutated_before_single_write() -> Result<()> {
+        use crate::containers::rdf::{Id as RdfId, Term as RdfTerm, Triple as RdfTriple};
+
+        init();
+        let mut hdt = Hdt::read_nt(Path::new("tests/resources/empty.nt"))?;
+        let triple = RdfTriple::new(
+            RdfId::Named("http://example.org/dataset".to_owned()),
+            "https://decisym.ai/de#graphIRI".to_owned(),
+            RdfTerm::Id(RdfId::Named("http://example.org/graph".to_owned())),
+        );
+        hdt.header_mut().body.insert(triple.clone());
+        hdt.recompute_header_length()?;
+
+        let mut buf = Vec::<u8>::new();
+        hdt.write(&mut buf)?;
+        let reloaded = Hdt::read(std::io::Cursor::new(buf))?;
+
+        assert!(reloaded.header().body.contains(&triple));
         Ok(())
     }
 

--- a/src/hdt.rs
+++ b/src/hdt.rs
@@ -7,9 +7,12 @@ use bytesize::ByteSize;
 use log::{debug, error};
 #[cfg(feature = "cache")]
 use std::fs::File;
+use std::io::{BufRead, Write};
 #[cfg(feature = "cache")]
-use std::io::{Seek, SeekFrom, Write};
+use std::io::{Seek, SeekFrom};
 use std::iter;
+#[cfg(feature = "cache")]
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 pub type Result<T> = core::result::Result<T, Error>;
@@ -62,8 +65,14 @@ pub enum Error {
 
 impl Hdt {
     #[deprecated(since = "0.4.0", note = "please use `read` instead")]
-    pub fn new<R: std::io::BufRead>(reader: R) -> Result<Self> {
+    pub fn new(reader: impl BufRead) -> Result<Self> {
         Self::read(reader)
+    }
+
+    /// Validates the leading global control info chunk, then returns the header section.
+    pub fn read_header<R: BufRead>(reader: &mut R) -> header::Result<Header> {
+        ControlInfo::read(reader)?;
+        Header::read(reader)
     }
 
     /// Creates an immutable HDT instance containing the dictionary and triples from the given reader.
@@ -76,9 +85,8 @@ impl Hdt {
     /// let file = std::fs::File::open("tests/resources/snikmeta.hdt").expect("error opening file");
     /// let hdt = hdt::Hdt::read(std::io::BufReader::new(file)).unwrap();
     /// ```
-    pub fn read<R: std::io::BufRead>(mut reader: R) -> Result<Self> {
-        ControlInfo::read(&mut reader)?;
-        let header = Header::read(&mut reader)?;
+    pub fn read<R: BufRead>(mut reader: R) -> Result<Self> {
+        let header = Self::read_header(&mut reader)?;
         let unvalidated_dict = FourSectDict::read(&mut reader)?;
         let triples = TriplesBitmap::read_sect(&mut reader)?;
         let dict = unvalidated_dict.validate()?;
@@ -90,7 +98,7 @@ impl Hdt {
 
     /// Write as N-Triples
     #[cfg(feature = "sophia")]
-    pub fn write_nt(&self, write: &mut impl std::io::Write) -> std::io::Result<()> {
+    pub fn write_nt(&self, write: &mut impl Write) -> std::io::Result<()> {
         use sophia::api::prelude::TripleSerializer;
         use sophia::turtle::serializer::nt::NtSerializer;
         NtSerializer::new(write).serialize_graph(self).map_err(|e| std::io::Error::other(format!("{e}")))?;
@@ -105,12 +113,11 @@ impl Hdt {
     /// The initial HDT specification at <http://www.w3.org/Submission/2011/03/> is outdated and not supported.
     /// # Example
     /// ```
-    /// let hdt = hdt::Hdt::read_from_path(std::path::Path::new("tests/resources/snikmeta.hdt")).unwrap();
+    /// let hdt = hdt::Hdt::read_from_path("tests/resources/snikmeta.hdt").unwrap();
     /// ```
     #[cfg(feature = "cache")]
-    pub fn read_from_path(f: &std::path::Path) -> Result<Self> {
-        use log::warn;
-
+    pub fn read_from_path(f: impl AsRef<Path>) -> Result<Self> {
+        let f = f.as_ref();
         let source = File::open(f)?;
         let mut reader = std::io::BufReader::new(source);
         ControlInfo::read(&mut reader)?;
@@ -125,7 +132,7 @@ impl Hdt {
             match Self::load_with_cache(&mut reader, &index_file_path, header.length) {
                 Ok(triples) => triples,
                 Err(e) => {
-                    warn!("error loading cache, overwriting: {e}");
+                    log::warn!("error loading cache, overwriting: {e}");
                     reader.seek(SeekFrom::Start(pos))?;
                     Self::load_without_cache(&mut reader, &index_file_path, header.length)?
                 }
@@ -142,8 +149,8 @@ impl Hdt {
     }
 
     #[cfg(feature = "cache")]
-    fn load_without_cache<R: std::io::BufRead>(
-        mut reader: R, index_file_path: &std::path::PathBuf, header_length: usize,
+    fn load_without_cache<R: BufRead>(
+        mut reader: R, index_file_path: &PathBuf, header_length: usize,
     ) -> Result<TriplesBitmap> {
         use log::warn;
 
@@ -157,8 +164,8 @@ impl Hdt {
     }
 
     #[cfg(feature = "cache")]
-    fn load_with_cache<R: std::io::BufRead>(
-        mut reader: R, index_file_path: &std::path::PathBuf, header_length: usize,
+    fn load_with_cache<R: BufRead>(
+        mut reader: R, index_file_path: &PathBuf, header_length: usize,
     ) -> core::result::Result<TriplesBitmap, Box<dyn std::error::Error>> {
         use std::io::Read;
         // load cached index
@@ -182,7 +189,7 @@ impl Hdt {
     /// Writes a custom cache file to improve load times. This cache file is usuable only by
     /// this library and is not intended to be used with hdt-cpp or hdt-java versions of the HDT tooling
     pub fn write_cache(
-        index_file_path: &std::path::PathBuf, triples: &TriplesBitmap, header_length: usize,
+        index_file_path: &PathBuf, triples: &TriplesBitmap, header_length: usize,
     ) -> core::result::Result<(), Box<dyn std::error::Error>> {
         let new_index_file = File::create(index_file_path)?;
         let mut writer = std::io::BufWriter::new(new_index_file);
@@ -192,7 +199,7 @@ impl Hdt {
         Ok(())
     }
 
-    pub fn write(&self, write: &mut impl std::io::Write) -> Result<()> {
+    pub fn write(&self, write: &mut impl Write) -> Result<()> {
         ControlInfo::global().write(write)?;
         self.header.write(write)?;
         self.dict.write(write)?;
@@ -411,17 +418,17 @@ pub mod tests {
     }
 
     #[test]
-    #[cfg(feature = "nt")]
-    fn header_metadata_can_be_mutated_before_single_write() -> Result<()> {
+    fn modify_header() -> Result<()> {
         use crate::containers::rdf::{Id as RdfId, Term as RdfTerm, Triple as RdfTriple};
 
         init();
-        let mut hdt = Hdt::read_nt(std::path::Path::new("tests/resources/empty.nt"))?;
+        let mut hdt = snikmeta()?;
         let triple = RdfTriple::new(
             RdfId::Named("http://example.org/dataset".to_owned()),
             "https://decisym.ai/de#graphIRI".to_owned(),
             RdfTerm::Id(RdfId::Named("http://example.org/graph".to_owned())),
         );
+        assert!(!hdt.header.body.contains(&triple));
         hdt.header.body.insert(triple.clone());
 
         let mut buf = Vec::<u8>::new();
@@ -438,7 +445,6 @@ pub mod tests {
     #[test]
     fn cache() -> Result<()> {
         use fs_err::remove_file;
-        use std::path::Path;
         init();
         // start with an empty cache
         let filename = "tests/resources/snikmeta.hdt";

--- a/src/hdt.rs
+++ b/src/hdt.rs
@@ -27,7 +27,7 @@ mod nt;
 pub struct Hdt {
     //global_ci: ControlInfo,
     // header is not necessary for querying but shouldn't waste too much space and we need it for writing in the future, may also make it optional
-    header: Header,
+    pub header: Header,
     /// in-memory representation of dictionary
     pub dict: FourSectDict,
     /// in-memory representation of triples
@@ -204,32 +204,6 @@ impl Hdt {
     /// Recursive size in bytes on the heap.
     pub fn size_in_bytes(&self) -> usize {
         self.dict.size_in_bytes() + self.triples.size_in_bytes()
-    }
-
-    /// Returns the HDT header.
-    pub fn header(&self) -> &Header {
-        &self.header
-    }
-
-    /// Returns a mutable HDT header.
-    ///
-    /// Call [`Self::recompute_header_length`] after mutating header triples so the
-    /// serialized header control information stays consistent.
-    pub fn header_mut(&mut self) -> &mut Header {
-        &mut self.header
-    }
-
-    /// Recomputes the serialized byte length for the current header body.
-    ///
-    /// This should be called after mutating [`Self::header_mut`].
-    pub fn recompute_header_length(&mut self) -> std::io::Result<()> {
-        use std::io::Write as _;
-        let mut buf = Vec::<u8>::new();
-        for triple in &self.header.body {
-            writeln!(&mut buf, "{triple}")?;
-        }
-        self.header.length = buf.len();
-        Ok(())
     }
 
     /// An iterator visiting *all* triples as strings in order.
@@ -448,14 +422,13 @@ pub mod tests {
             "https://decisym.ai/de#graphIRI".to_owned(),
             RdfTerm::Id(RdfId::Named("http://example.org/graph".to_owned())),
         );
-        hdt.header_mut().body.insert(triple.clone());
-        hdt.recompute_header_length()?;
+        hdt.header.body.insert(triple.clone());
 
         let mut buf = Vec::<u8>::new();
         hdt.write(&mut buf)?;
         let reloaded = Hdt::read(std::io::Cursor::new(buf))?;
 
-        assert!(reloaded.header().body.contains(&triple));
+        assert!(reloaded.header.body.contains(&triple));
         Ok(())
     }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -2,7 +2,10 @@ use crate::containers::ControlInfo;
 use crate::containers::rdf::{Id, Literal, Term, Triple};
 use ntriple::parser::triple_line;
 use std::collections::BTreeSet;
+use std::fs::File;
 use std::io::BufRead;
+use std::io::BufReader;
+use std::path::Path;
 use std::str;
 
 pub type Result<T> = core::result::Result<T, Error>;
@@ -35,6 +38,17 @@ pub enum Error {
 }
 
 impl Header {
+    /// Reads the header section directly from an HDT file path.
+    ///
+    /// This reads and validates the leading global control info chunk, then
+    /// parses the header section.
+    pub fn read_from_hdt_path(path: &Path) -> Result<Self> {
+        let file = File::open(path)?;
+        let mut reader = BufReader::new(file);
+        ControlInfo::read(&mut reader)?;
+        Self::read(&mut reader)
+    }
+
     /// Reader needs to be positioned directly after the global control information.
     pub fn read<R: BufRead>(reader: &mut R) -> Result<Self> {
         let header_ci = ControlInfo::read(reader)?;
@@ -96,17 +110,11 @@ impl Header {
 mod tests {
     use super::*;
     use crate::tests::init;
-    use fs_err::File;
-    use std::io::BufReader;
 
     #[test]
     fn read_header() -> color_eyre::Result<()> {
         init();
-        let file = File::open("tests/resources/yago_header.hdt")?;
-        let mut reader = BufReader::new(file);
-        ControlInfo::read(&mut reader)?;
-
-        let header = Header::read(&mut reader)?;
+        let header = Header::read_from_hdt_path(Path::new("tests/resources/yago_header.hdt"))?;
         assert_eq!(header.format, "ntriples");
         assert_eq!(header.length, 1891);
         assert_eq!(header.body.len(), 22);

--- a/src/header.rs
+++ b/src/header.rs
@@ -98,10 +98,13 @@ impl Header {
     }
 
     pub fn write(&self, write: &mut impl std::io::Write) -> Result<()> {
-        ControlInfo::header(self.length).write(write)?;
+        use std::io::Write as _;
+        let mut body = Vec::<u8>::new();
         for triple in &self.body {
-            writeln!(write, "{triple}")?;
+            writeln!(&mut body, "{triple}")?;
         }
+        ControlInfo::header(body.len()).write(write)?;
+        write.write_all(&body)?;
         Ok(())
     }
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -2,10 +2,7 @@ use crate::containers::ControlInfo;
 use crate::containers::rdf::{Id, Literal, Term, Triple};
 use ntriple::parser::triple_line;
 use std::collections::BTreeSet;
-use std::fs::File;
-use std::io::BufRead;
-use std::io::BufReader;
-use std::path::Path;
+use std::io::{BufRead, Write};
 use std::str;
 
 pub type Result<T> = core::result::Result<T, Error>;
@@ -38,17 +35,6 @@ pub enum Error {
 }
 
 impl Header {
-    /// Reads the header section directly from an HDT file path.
-    ///
-    /// This reads and validates the leading global control info chunk, then
-    /// parses the header section.
-    pub fn read_from_hdt_path(path: &Path) -> Result<Self> {
-        let file = File::open(path)?;
-        let mut reader = BufReader::new(file);
-        ControlInfo::read(&mut reader)?;
-        Self::read(&mut reader)
-    }
-
     /// Reader needs to be positioned directly after the global control information.
     pub fn read<R: BufRead>(reader: &mut R) -> Result<Self> {
         let header_ci = ControlInfo::read(reader)?;
@@ -97,8 +83,7 @@ impl Header {
         Ok(Header { format: header_ci.format, length, body })
     }
 
-    pub fn write(&self, write: &mut impl std::io::Write) -> Result<()> {
-        use std::io::Write as _;
+    pub fn write(&self, write: &mut impl Write) -> Result<()> {
         let mut body = Vec::<u8>::new();
         for triple in &self.body {
             writeln!(&mut body, "{triple}")?;
@@ -111,13 +96,13 @@ impl Header {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::tests::init;
 
     #[test]
     fn read_header() -> color_eyre::Result<()> {
         init();
-        let header = Header::read_from_hdt_path(Path::new("tests/resources/yago_header.hdt"))?;
+        let mut r = std::io::BufReader::new(std::fs::File::open("tests/resources/yago_header.hdt")?);
+        let header = crate::Hdt::read_header(&mut r)?;
         assert_eq!(header.format, "ntriples");
         assert_eq!(header.length, 1891);
         assert_eq!(header.body.len(), 22);

--- a/src/nt.rs
+++ b/src/nt.rs
@@ -48,7 +48,6 @@ impl Hdt {
         use crate::containers::rdf::Term::Literal as Lit;
         use crate::containers::rdf::{Id, Literal, Term, Triple};
         use crate::vocab::*;
-        use std::io::Write;
 
         const ORDER: &str = "SPO";
 
@@ -104,11 +103,6 @@ impl Hdt {
         // exclude for now to skip dependency on chrono
         //let datetime_str = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S%z").to_string();
         //literal!(pub_id,DC_TERMS_ISSUED,datetime_str);
-        let mut buf = Vec::<u8>::new();
-        for triple in &self.header.body {
-            writeln!(buf, "{triple}")?;
-        }
-        self.header.length = buf.len();
         Ok(())
     }
 }

--- a/src/nt.rs
+++ b/src/nt.rs
@@ -21,12 +21,12 @@ impl Hdt {
     /// Converts RDF N-Triples to HDT with a FourSectionDictionary with DictionarySectionPlainFrontCoding and SPO order.
     /// *This function is available only if HDT is built with the experimental `"nt"` feature.*
     /// # Example
-    /// ```no_run
-    /// let path = std::path::Path::new("example.nt");
-    /// let hdt = hdt::Hdt::read_nt(path).unwrap();
     /// ```
-    pub fn read_nt(f: &Path) -> Result<Self> {
+    /// let hdt = hdt::Hdt::read_nt("tests/resources/empty.nt").unwrap();
+    /// ```
+    pub fn read_nt(f: impl AsRef<Path>) -> Result<Self> {
         const BLOCK_SIZE: usize = 16;
+        let f = f.as_ref();
 
         let (dict, mut encoded_triples) = read_dict_triples(f, BLOCK_SIZE)?;
         let num_triples = encoded_triples.len();


### PR DESCRIPTION
This one's closer to a feature request, but can the HDT Header field be mutable? When running the read_nt() conversion, it would be nice to be able to add/update Header triples for the generated HDT before ultimately writing it to disk. Willing to put the new logic behind the `nt` feature flag if it makes more sense