### PR TITLE
refactor: start to update and adapt to Sophia 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 bytesize = "2"
 crc = "3"
 ntriple = "0.1"
-sophia = { version = "0.9", optional = true }
+sophia = { version = "0.10", optional = true }
 thiserror = "2"
 log = "0.4"
 env_logger = { version = "0.11", default-features = false, features = ["auto-color"] }

--- a/src/hdt.rs
+++ b/src/hdt.rs
@@ -92,8 +92,8 @@ impl Hdt {
     #[cfg(feature = "sophia")]
     pub fn write_nt(&self, write: &mut impl std::io::Write) -> std::io::Result<()> {
         use sophia::api::prelude::TripleSerializer;
-        use sophia::turtle::serializer::nt::NtSerializer;
-        NtSerializer::new(write).serialize_graph(self).map_err(|e| std::io::Error::other(format!("{e}")))?;
+        use sophia::turtle::serializer::nt::NTriplesSerializer;
+        NTriplesSerializer::new(write).serialize_graph(self).map_err(|e| std::io::Error::other(format!("{e}")))?;
         Ok(())
     }
 

--- a/src/hdt_graph.rs
+++ b/src/hdt_graph.rs
@@ -135,13 +135,14 @@ impl Graph for Hdt {
     ///     let persons = dbpedia.triples_matching(Any, Some(birth_place), Some(leipzig));
     /// }
     /// ```
-    fn triples_matching<'s, S, P, O>(
+    fn triples_matching<'s, 't, S, P, O>(
         &'s self, sm: S, pm: P, om: O,
-    ) -> impl Iterator<Item = Result<Self::Triple<'s>, Self::Error>> + 's
+    ) -> impl Iterator<Item = Result<Self::Triple<'s>, Self::Error>> + 't
     where
-        S: TermMatcher + 's,
-        P: TermMatcher + 's,
-        O: TermMatcher + 's,
+        's: 't,
+        S: TermMatcher + 't,
+        P: TermMatcher + 't,
+        O: TermMatcher + 't,
     {
         use HdtMatcher::{Constant, Other};
         let Some(xso) = unpack_matcher(self, &sm, IdKind::Subject) else {

--- a/src/hdt_graph/term.rs
+++ b/src/hdt_graph/term.rs
@@ -1,7 +1,7 @@
 //! I define [`HdtTerm`], an implementation of [`sophia::api::term::Term`].
 use sophia::api::MownStr;
 use sophia::api::ns::{rdf, xsd};
-use sophia::api::term::{BnodeId, LanguageTag, Term, TermKind};
+use sophia::api::term::{BaseDirection, BnodeId, LanguageTag, Term, TermKind};
 use sophia::iri::IriRef;
 use std::sync::{Arc, LazyLock};
 
@@ -95,6 +95,11 @@ impl Term for HdtTerm {
             HdtTerm::LiteralLanguage(_, tag) => Some(tag.as_ref().map_unchecked(MownStr::from_ref)),
             _ => None,
         }
+    }
+
+    // added in Sophia 0.10; as we don't support RDF 1.2 base directions return None for now
+    fn base_direction(&self) -> Option<BaseDirection> {
+        None
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use sophia::api::prelude::{TripleSerializer, TripleSource};
 //use sophia::api::prelude::Stringifier;
 use sophia::inmem::graph::LightGraph;
 use sophia::turtle::parser::{nt, turtle};
-use sophia::turtle::serializer::nt::NtSerializer;
+use sophia::turtle::serializer::nt::NTriplesSerializer;
 use sophia::turtle::serializer::turtle::{TurtleConfig, TurtleSerializer};
 use std::ffi::OsStr;
 use std::io::{BufReader, BufWriter};
@@ -151,7 +151,7 @@ fn main() -> Result<(), Report> {
                 Some("nt") => {
                     // Default: export the complete graph as N-Triples.
                     //NtSerializer::new_stringifier()
-                    NtSerializer::new(writer)
+                    NTriplesSerializer::new(writer)
                         .serialize_graph(&hdt)
                         .wrap_err("error serializing graph as N-Triples")?;
                     //.to_string()

--- a/src/sparql.rs
+++ b/src/sparql.rs
@@ -202,62 +202,68 @@ mod tests {
 
         // Find the manifest node
         let p = MF.get("entries")?;
-        let manifest_nodes: Vec<_> = g.triples_matching(Any, [&p], Any).collect();
+        let manifest_nodes: Vec<_> = g.triples_matching(Any, Some(&p), Any).collect();
         if manifest_nodes.is_empty() {
             return Ok(cases);
         }
 
         // The object of mf:entries is the head of an RDF list
-        let list_head = manifest_nodes[0]?.o().clone();
+        let list_head = manifest_nodes[0]?.o();
 
         // Walk the RDF list
         let mut current = list_head;
         while !current.is_iri() || current.iri().unwrap() != rdf::nil.to_iriref() {
             if let Some(test) = g
-                .triples_matching([&current], [&rdf::first, &MF.get("QueryEvaluationTest")?], Any)
+                .triples_matching(Some(&current.as_simple()), [&rdf::first, &MF.get("QueryEvaluationTest")?], Any)
                 .next()
-                .map(|t| t.unwrap().o().clone())
+                .map(|t| t.unwrap().o())
             {
                 // find mf:action
-                if let Some(action_node) =
-                    g.triples_matching([&test], [&MF.get("action")?], Any).next().map(|t| t.unwrap().o().clone())
+                if let Some(action_node) = g
+                    .triples_matching(Some(&test.as_simple()), Some(&MF.get("action")?), Any)
+                    .next()
+                    .map(|t| t.unwrap().o())
                 {
                     // find qt:data
-                    let data = g.triples_matching([&action_node], [&QT.get("data")?], Any).next().map(|t| match t
-                        .unwrap()
-                        .o()
-                    {
-                        SimpleTerm::BlankNode(b) => b.to_string(),
-                        SimpleTerm::Iri(i) => i.to_string(),
-                        SimpleTerm::LiteralDatatype(a, _b) => a.to_string(),
-                        SimpleTerm::LiteralLanguage(a, _b) => a.to_string(),
-                        SimpleTerm::Triple(_t) => todo!(),
-                        SimpleTerm::Variable(v) => v.to_string(),
-                    });
-
-                    // find qt:query
-                    let query =
-                        g.triples_matching([&action_node], [&QT.get("query")?], Any).next().map(|t| {
-                            match t.unwrap().o() {
+                    let data = g
+                        .triples_matching(Some(&action_node.as_simple()), Some(&QT.get("data")?), Any)
+                        .next()
+                        .map(|t| {
+                            let obj = t.unwrap().o();
+                            match obj.as_simple() {
                                 SimpleTerm::BlankNode(b) => b.to_string(),
                                 SimpleTerm::Iri(i) => i.to_string(),
                                 SimpleTerm::LiteralDatatype(a, _b) => a.to_string(),
-                                SimpleTerm::LiteralLanguage(a, _b) => a.to_string(),
+                                SimpleTerm::LiteralLanguage(a, _b, _) => a.to_string(),
                                 SimpleTerm::Triple(_t) => todo!(),
                                 SimpleTerm::Variable(v) => v.to_string(),
                             }
                         });
-                    // find mf:result
-                    let result = g.triples_matching([&test], [&MF.get("result")?], Any).next().map(|t| {
-                        match t.unwrap().o() {
+
+                    // find qt:query
+                    let query = g
+                        .triples_matching(Some(&action_node.as_simple()), Some(&QT.get("query")?), Any)
+                        .next()
+                        .map(|t| match t.unwrap().o().as_simple() {
                             SimpleTerm::BlankNode(b) => b.to_string(),
                             SimpleTerm::Iri(i) => i.to_string(),
                             SimpleTerm::LiteralDatatype(a, _b) => a.to_string(),
-                            SimpleTerm::LiteralLanguage(a, _b) => a.to_string(),
+                            SimpleTerm::LiteralLanguage(a, _b, _) => a.to_string(),
                             SimpleTerm::Triple(_t) => todo!(),
                             SimpleTerm::Variable(v) => v.to_string(),
-                        }
-                    });
+                        });
+                    // find mf:result
+                    let result = g
+                        .triples_matching(Some(&test.as_simple()), Some(&MF.get("result")?), Any)
+                        .next()
+                        .map(|t| match t.unwrap().o().as_simple() {
+                            SimpleTerm::BlankNode(b) => b.to_string(),
+                            SimpleTerm::Iri(i) => i.to_string(),
+                            SimpleTerm::LiteralDatatype(a, _b) => a.to_string(),
+                            SimpleTerm::LiteralLanguage(a, _b, _) => a.to_string(),
+                            SimpleTerm::Triple(_t) => todo!(),
+                            SimpleTerm::Variable(v) => v.to_string(),
+                        });
 
                     if let (Some(data), Some(query), Some(result)) = (data, query, result) {
                         cases.push(TestCase {
@@ -269,8 +275,9 @@ mod tests {
                 }
             }
 
-            let s = current.clone();
-            if let Some(next) = g.triples_matching([&s], [&rdf::rest], Any).next().map(|t| t.unwrap().o().clone())
+            let s = current;
+            if let Some(next) =
+                g.triples_matching(Some(&s.as_simple()), Some(&rdf::rest), Any).next().map(|t| t.unwrap().o())
             {
                 current = next;
             } else {

--- a/src/sparql.rs
+++ b/src/sparql.rs
@@ -94,7 +94,9 @@ mod tests {
     use sophia::api::prelude::{Any, Triple, TripleSerializer, TripleSource};
     use sophia::api::term::{SimpleTerm, Term};
     use sophia::inmem::graph::FastGraph;
-    use sophia::turtle::serializer::nt::NtSerializer;
+    use sophia::iri::resolve::BaseIriRef;
+    use sophia::turtle::parser::turtle::TurtleParser;
+    use sophia::turtle::serializer::nt::NTriplesSerializer;
     use std::collections::HashMap;
     use std::io::{BufReader, Write};
     use std::path::{Path, PathBuf};
@@ -164,15 +166,13 @@ mod tests {
         let nt_file = File::options().read(true).write(true).create(true).truncate(true).open(dest_nt)?;
         let mut writer = std::io::BufWriter::new(nt_file);
         let mut graph = sophia::inmem::graph::LightGraph::default();
-        let mut sophia_serializer = NtSerializer::new(writer.by_ref());
+        let mut sophia_serializer = NTriplesSerializer::new(writer.by_ref());
 
         if source_rdf.extension().is_some_and(|ext| ext == ".ttl") {
-            let ttl_parser = sophia::turtle::parser::turtle::TurtleParser {
-                base: Some(sophia::iri::Iri::new(format!(
-                    "file://{}",
-                    std::path::Path::new(source_rdf).file_name().unwrap().to_str().unwrap()
-                ))?),
-            };
+            let base_iri_string =
+                format!("file://{}", std::path::Path::new(source_rdf).file_name().unwrap().to_str().unwrap())
+                    .into_boxed_str();
+            let ttl_parser = TurtleParser { base: Some(BaseIriRef::new(base_iri_string)?), ..Default::default() };
 
             ttl_parser.parse(reader).add_to_graph(&mut graph)?;
         }
@@ -186,12 +186,10 @@ mod tests {
     fn load_manifest(path: &Path) -> Result<FastGraph, Box<dyn std::error::Error>> {
         let file = BufReader::new(File::open(path)?);
         let mut graph = sophia::inmem::graph::FastGraph::default();
-        let ttl_parser = sophia::turtle::parser::turtle::TurtleParser {
-            base: Some(sophia::iri::Iri::new(format!(
-                "file://{}/#",
-                std::path::Path::new(path).parent().unwrap().to_str().unwrap()
-            ))?),
-        };
+        let base_iri_string =
+            format!("file://{}/#", std::path::Path::new(path).parent().unwrap().to_str().unwrap())
+                .into_boxed_str();
+        let ttl_parser = TurtleParser { base: Some(BaseIriRef::new(base_iri_string)?), ..Default::default() };
 
         ttl_parser.parse(file).add_to_graph(&mut graph)?;
         Ok(graph)


### PR DESCRIPTION
test_graph still fails, I just did a quick refactor to the new trait, need some time later to figure out what changed with the new release.

```sh
hdt$ cargo test test_graph
    Finished `test` profile [optimized + debuginfo] target(s) in 0.05s
     Running unittests src/lib.rs (target/debug/deps/hdt-c6ba548a9683a17d)

running 1 test
test hdt_graph::tests::test_graph ... FAILED

failures:

---- hdt_graph::tests::test_graph stdout ----
The application panicked (crashed).
Message:  not implemented: Default implementation should have been overridden
Location: /home/konrad/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sophia_api-0.10.0/src/term.rs:249
```