### PR TITLE
feat: decode-only Hdt::triples_streaming (skip query-index build on bulk reads)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ fs-err = { version = "3.1.0", optional = true }
 bitset-core = { version = "0.1.1", optional = true }
 oxttl = { version = "0.2.1", optional = true }
 lasso = { version = "0.7.3", features = ["multi-threaded"], optional = true }
-qwt = "0.3.5"
+qwt = "0.4"
 
 [features]
 default = ["sophia"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,8 @@ pub mod header;
 pub mod sparql;
 /// Types for representing and querying triples.
 pub mod triples;
+/// Decode-only streaming of triple IDs without building the query indexes.
+pub mod triples_streaming;
 /// Constants for triple terms
 pub mod vocab;
 #[cfg(target_arch = "wasm32")]

--- a/src/triples_streaming.rs
+++ b/src/triples_streaming.rs
@@ -128,7 +128,9 @@ impl Hdt {
 
 #[cfg(test)]
 mod tests {
+    use crate::hdt::tests::snikmeta;
     use crate::{Hdt, IdKind};
+    use color_eyre::Result;
     use std::collections::BTreeSet;
     use std::fs::File;
     use std::io::BufReader;
@@ -138,14 +140,13 @@ mod tests {
     /// The decode-only stream must yield exactly the same triples (as resolved term
     /// strings) as the full `Hdt::read` path, which builds the query indexes.
     #[test]
-    fn streaming_matches_full_read() {
+    fn streaming_matches_full_read() -> Result<()> {
         // Full path: build everything, collect resolved triples.
-        let full = Hdt::read(BufReader::new(File::open(SNIKMETA).unwrap())).unwrap();
         let expected: BTreeSet<[String; 3]> =
-            full.triples_all().map(|[s, p, o]| [s.to_string(), p.to_string(), o.to_string()]).collect();
+            snikmeta()?.triples_all().map(|[s, p, o]| [s.to_string(), p.to_string(), o.to_string()]).collect();
 
         // Decode-only path: stream IDs, resolve through the dictionary, no indexes built.
-        let (dict, stream) = Hdt::triples_streaming(BufReader::new(File::open(SNIKMETA).unwrap())).unwrap();
+        let (dict, stream) = Hdt::triples_streaming(BufReader::new(File::open(SNIKMETA)?))?;
         let got: BTreeSet<[String; 3]> = stream
             .map(|[s, p, o]| {
                 [
@@ -158,5 +159,6 @@ mod tests {
 
         assert!(!expected.is_empty(), "fixture must contain triples");
         assert_eq!(expected, got, "decode-only stream must equal the full read path");
+        Ok(())
     }
 }

--- a/src/triples_streaming.rs
+++ b/src/triples_streaming.rs
@@ -1,27 +1,6 @@
-//! Decode-only, one-shot streaming of every triple in an HDT archive in SPO
-//! order, **without** building the [`TriplesBitmap`](crate::triples::TriplesBitmap)
-//! query indexes.
-//!
-//! [`Hdt::read`](crate::Hdt::read) calls [`TriplesBitmap::read_sect`], which in
-//! turn calls [`TriplesBitmap::new`]. That constructor exists purely to serve
-//! triple-pattern / object / predicate *queries*: it builds a wavelet matrix over
-//! `sequence_y`, a per-object `Vec<Vec<u32>>`, a `sort_by_cached_key`, and an
-//! object-predicate index (a compact vector + a rank/select bitmap). A consumer
-//! that only wants to read every triple once — e.g. a bulk import into another
-//! store — issues none of those queries, so all of that work is performed and then
-//! immediately dropped.
-//!
-//! [`Hdt::triples_streaming`] reads the same on-disk sections the full path reads
-//! (the global control info + header, the four-section dictionary, and the triples
-//! section's `bitmap_y` / `bitmap_z` / `sequence_y` / `sequence_z`) and walks the
-//! adjacency lists sequentially to yield `[usize; 3]` triple IDs, skipping
-//! `TriplesBitmap::new` entirely. The walk is the same one [`SubjectIter`] performs
-//! over the built structure, but reads the predicate from `sequence_y` and the
-//! end-of-run flags from the two bitmaps directly.
-//!
-//! [`SubjectIter`]: crate::triples::SubjectIter
-//! [`TriplesBitmap::read_sect`]: crate::triples::TriplesBitmap::read_sect
-//! [`TriplesBitmap::new`]: crate::triples::TriplesBitmap::new
+//! Decode-only streaming of every triple in SPO order, without building the
+//! `TriplesBitmap` query indexes. For one-shot bulk reads where no triple-pattern
+//! query is ever issued, e.g. importing every triple into another store.
 
 use crate::Hdt;
 use crate::containers::{Bitmap, ControlInfo, ControlType, Sequence};
@@ -29,9 +8,8 @@ use crate::four_sect_dict::FourSectDict;
 use crate::header::Header;
 use std::io::{self, BufRead, Error, ErrorKind};
 
-/// The triples section, read but not indexed: the two adjacency bitmaps and the two
-/// ID sequences exactly as they appear on disk. Walking these yields every triple in
-/// SPO order without the wavelet matrix / OP-index that `TriplesBitmap::new` builds.
+/// The triples section read but not indexed: the two adjacency bitmaps and the two
+/// ID sequences as they appear on disk. Walking these yields every triple in SPO order.
 struct StreamingTriples {
     bitmap_y: Bitmap,
     bitmap_z: Bitmap,
@@ -40,10 +18,7 @@ struct StreamingTriples {
 }
 
 impl StreamingTriples {
-    /// Reads the triples section (control info + the two bitmaps + the two
-    /// sequences) without building any query index. Mirrors the section order of
-    /// [`TriplesBitmap::read`](crate::triples::TriplesBitmap), minus the
-    /// `TriplesBitmap::new` call.
+    /// Reads the triples section without building any query index.
     fn read<R: BufRead>(reader: &mut R) -> io::Result<Self> {
         let triples_ci =
             ControlInfo::read(reader).map_err(|e| Error::new(ErrorKind::InvalidData, e.to_string()))?;
@@ -84,9 +59,7 @@ impl StreamingTriples {
 }
 
 /// Iterator over `[subject_id, predicate_id, object_id]` triples in SPO order,
-/// produced by [`Hdt::triples_streaming`] without any query index. IDs are 1-based,
-/// as in the HDT dictionary; resolve them through the dictionary returned alongside
-/// the iterator if string terms are needed.
+/// produced by [`Hdt::triples_streaming`]. IDs are 1-based, as in the HDT dictionary.
 pub struct TripleIdStreamingIter {
     triples: StreamingTriples,
     x: usize,
@@ -107,10 +80,6 @@ impl TripleIdStreamingIter {
 impl Iterator for TripleIdStreamingIter {
     type Item = [usize; 3];
 
-    /// Sequential SPO walk, identical in shape to [`SubjectIter::next`], but reading
-    /// the predicate from `sequence_y` and the run-end flags from the raw bitmaps.
-    ///
-    /// [`SubjectIter::next`]: crate::triples::SubjectIter
     fn next(&mut self) -> Option<[usize; 3]> {
         if self.pos_y >= self.max_y || self.pos_z >= self.max_z {
             return None;
@@ -132,18 +101,11 @@ impl Iterator for TripleIdStreamingIter {
 }
 
 impl Hdt {
-    /// Decode-only: read the dictionary, then stream every triple as `[s, p, o]`
-    /// dictionary IDs in SPO order **without** building the wavelet matrix / OP-index
-    /// that [`Hdt::read`] constructs for pattern queries.
-    ///
-    /// This is intended for one-shot bulk reads (e.g. importing every triple into
-    /// another store) where none of the query indexes are ever used. It returns the
-    /// validated [`FourSectDict`] dictionary (so IDs can be resolved to terms) and an
-    /// iterator over the triple IDs. The IDs follow the HDT convention: subjects and
-    /// objects share the leading "shared" section, predicates are a separate space;
-    /// use [`FourSectDict::id_to_string`] with the appropriate
-    /// [`IdKind`](crate::IdKind) to resolve them.
-    ///
+    /// Reads the dictionary, then streams every triple as `[s, p, o]` dictionary IDs
+    /// in SPO order without building the query indexes that [`Hdt::read`] constructs.
+    /// Intended for one-shot bulk reads where no triple-pattern query is issued.
+    /// Returns the validated dictionary, so IDs can be resolved to terms with
+    /// [`FourSectDict::id_to_string`] and the matching [`IdKind`](crate::IdKind).
     /// # Example
     /// ```
     /// let file = std::fs::File::open("tests/resources/snikmeta.hdt").expect("open");

--- a/src/triples_streaming.rs
+++ b/src/triples_streaming.rs
@@ -1,6 +1,4 @@
-//! Decode-only streaming of every triple in SPO order, without building the
-//! `TriplesBitmap` query indexes. For one-shot bulk reads where no triple-pattern
-//! query is ever issued, e.g. importing every triple into another store.
+//! Decode-only streaming of every triple in SPO order without building the `TriplesBitmap` query indexes.
 
 use crate::Hdt;
 use crate::containers::{Bitmap, ControlInfo, ControlType, Sequence};

--- a/src/triples_streaming.rs
+++ b/src/triples_streaming.rs
@@ -1,0 +1,202 @@
+//! Decode-only, one-shot streaming of every triple in an HDT archive in SPO
+//! order, **without** building the [`TriplesBitmap`](crate::triples::TriplesBitmap)
+//! query indexes.
+//!
+//! [`Hdt::read`](crate::Hdt::read) calls [`TriplesBitmap::read_sect`], which in
+//! turn calls [`TriplesBitmap::new`]. That constructor exists purely to serve
+//! triple-pattern / object / predicate *queries*: it builds a wavelet matrix over
+//! `sequence_y`, a per-object `Vec<Vec<u32>>`, a `sort_by_cached_key`, and an
+//! object-predicate index (a compact vector + a rank/select bitmap). A consumer
+//! that only wants to read every triple once — e.g. a bulk import into another
+//! store — issues none of those queries, so all of that work is performed and then
+//! immediately dropped.
+//!
+//! [`Hdt::triples_streaming`] reads the same on-disk sections the full path reads
+//! (the global control info + header, the four-section dictionary, and the triples
+//! section's `bitmap_y` / `bitmap_z` / `sequence_y` / `sequence_z`) and walks the
+//! adjacency lists sequentially to yield `[usize; 3]` triple IDs, skipping
+//! `TriplesBitmap::new` entirely. The walk is the same one [`SubjectIter`] performs
+//! over the built structure, but reads the predicate from `sequence_y` and the
+//! end-of-run flags from the two bitmaps directly.
+//!
+//! [`SubjectIter`]: crate::triples::SubjectIter
+//! [`TriplesBitmap::read_sect`]: crate::triples::TriplesBitmap::read_sect
+//! [`TriplesBitmap::new`]: crate::triples::TriplesBitmap::new
+
+use crate::Hdt;
+use crate::containers::{Bitmap, ControlInfo, ControlType, Sequence};
+use crate::four_sect_dict::FourSectDict;
+use crate::header::Header;
+use std::io::{self, BufRead, Error, ErrorKind};
+
+/// The triples section, read but not indexed: the two adjacency bitmaps and the two
+/// ID sequences exactly as they appear on disk. Walking these yields every triple in
+/// SPO order without the wavelet matrix / OP-index that `TriplesBitmap::new` builds.
+struct StreamingTriples {
+    bitmap_y: Bitmap,
+    bitmap_z: Bitmap,
+    sequence_y: Sequence,
+    sequence_z: Sequence,
+}
+
+impl StreamingTriples {
+    /// Reads the triples section (control info + the two bitmaps + the two
+    /// sequences) without building any query index. Mirrors the section order of
+    /// [`TriplesBitmap::read`](crate::triples::TriplesBitmap), minus the
+    /// `TriplesBitmap::new` call.
+    fn read<R: BufRead>(reader: &mut R) -> io::Result<Self> {
+        let triples_ci =
+            ControlInfo::read(reader).map_err(|e| Error::new(ErrorKind::InvalidData, e.to_string()))?;
+        if triples_ci.control_type != ControlType::Triples {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("expected triples control info, got {:?}", triples_ci.control_type),
+            ));
+        }
+        match triples_ci.format.as_str() {
+            "<http://purl.org/HDT/hdt#triplesBitmap>" => {}
+            "<http://purl.org/HDT/hdt#triplesList>" => {
+                return Err(Error::new(ErrorKind::InvalidData, "triples list format is not supported"));
+            }
+            f => return Err(Error::new(ErrorKind::InvalidData, format!("unknown triples format {f}"))),
+        }
+        // Only SPO (order 1) is supported, matching the full read path.
+        match triples_ci.get("order").and_then(|v| v.parse::<u32>().ok()) {
+            Some(1) => {}
+            other => {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    format!("unsupported triples order {other:?} (only SPO is supported)"),
+                ));
+            }
+        }
+
+        // Same on-disk order as TriplesBitmap::read: bitmap_y, bitmap_z, sequence_y, sequence_z.
+        let to_io = |e: crate::containers::bitmap::Error| Error::new(ErrorKind::InvalidData, e.to_string());
+        let bitmap_y = Bitmap::read(reader).map_err(to_io)?;
+        let bitmap_z = Bitmap::read(reader).map_err(to_io)?;
+        let seq_io = |e: crate::containers::sequence::Error| Error::new(ErrorKind::InvalidData, e.to_string());
+        let sequence_y = Sequence::read(reader).map_err(seq_io)?;
+        let sequence_z = Sequence::read(reader).map_err(seq_io)?;
+
+        Ok(StreamingTriples { bitmap_y, bitmap_z, sequence_y, sequence_z })
+    }
+}
+
+/// Iterator over `[subject_id, predicate_id, object_id]` triples in SPO order,
+/// produced by [`Hdt::triples_streaming`] without any query index. IDs are 1-based,
+/// as in the HDT dictionary; resolve them through the dictionary returned alongside
+/// the iterator if string terms are needed.
+pub struct TripleIdStreamingIter {
+    triples: StreamingTriples,
+    x: usize,
+    pos_y: usize,
+    pos_z: usize,
+    max_y: usize,
+    max_z: usize,
+}
+
+impl TripleIdStreamingIter {
+    const fn new(triples: StreamingTriples) -> Self {
+        let max_y = triples.sequence_y.entries;
+        let max_z = triples.sequence_z.entries;
+        TripleIdStreamingIter { triples, x: 1, pos_y: 0, pos_z: 0, max_y, max_z }
+    }
+}
+
+impl Iterator for TripleIdStreamingIter {
+    type Item = [usize; 3];
+
+    /// Sequential SPO walk, identical in shape to [`SubjectIter::next`], but reading
+    /// the predicate from `sequence_y` and the run-end flags from the raw bitmaps.
+    ///
+    /// [`SubjectIter::next`]: crate::triples::SubjectIter
+    fn next(&mut self) -> Option<[usize; 3]> {
+        if self.pos_y >= self.max_y || self.pos_z >= self.max_z {
+            return None;
+        }
+        let s = self.x;
+        let p = self.triples.sequence_y.get(self.pos_y);
+        let o = self.triples.sequence_z.get(self.pos_z);
+
+        // at_last_sibling reads the bit at the given position without rank/select.
+        if self.triples.bitmap_z.at_last_sibling(self.pos_z) {
+            if self.triples.bitmap_y.at_last_sibling(self.pos_y) {
+                self.x += 1;
+            }
+            self.pos_y += 1;
+        }
+        self.pos_z += 1;
+        Some([s, p, o])
+    }
+}
+
+impl Hdt {
+    /// Decode-only: read the dictionary, then stream every triple as `[s, p, o]`
+    /// dictionary IDs in SPO order **without** building the wavelet matrix / OP-index
+    /// that [`Hdt::read`] constructs for pattern queries.
+    ///
+    /// This is intended for one-shot bulk reads (e.g. importing every triple into
+    /// another store) where none of the query indexes are ever used. It returns the
+    /// validated [`FourSectDict`] dictionary (so IDs can be resolved to terms) and an
+    /// iterator over the triple IDs. The IDs follow the HDT convention: subjects and
+    /// objects share the leading "shared" section, predicates are a separate space;
+    /// use [`FourSectDict::id_to_string`] with the appropriate
+    /// [`IdKind`](crate::IdKind) to resolve them.
+    ///
+    /// # Example
+    /// ```
+    /// let file = std::fs::File::open("tests/resources/snikmeta.hdt").expect("open");
+    /// let (dict, triples) = hdt::Hdt::triples_streaming(std::io::BufReader::new(file)).unwrap();
+    /// let count = triples.count();
+    /// assert!(count > 0);
+    /// let _ = dict;
+    /// ```
+    pub fn triples_streaming<R: BufRead>(mut reader: R) -> io::Result<(FourSectDict, TripleIdStreamingIter)> {
+        // Global control info + header, then the four-section dictionary.
+        ControlInfo::read(&mut reader).map_err(|e| Error::new(ErrorKind::InvalidData, e.to_string()))?;
+        Header::read(&mut reader).map_err(|e| Error::new(ErrorKind::InvalidData, e.to_string()))?;
+        let dict = FourSectDict::read(&mut reader)
+            .map_err(|e| Error::new(ErrorKind::InvalidData, e.to_string()))?
+            .validate()
+            .map_err(|e| Error::new(ErrorKind::InvalidData, e.to_string()))?;
+
+        let triples = StreamingTriples::read(&mut reader)?;
+        Ok((dict, TripleIdStreamingIter::new(triples)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Hdt, IdKind};
+    use std::collections::BTreeSet;
+    use std::fs::File;
+    use std::io::BufReader;
+
+    const SNIKMETA: &str = "tests/resources/snikmeta.hdt";
+
+    /// The decode-only stream must yield exactly the same triples (as resolved term
+    /// strings) as the full `Hdt::read` path, which builds the query indexes.
+    #[test]
+    fn streaming_matches_full_read() {
+        // Full path: build everything, collect resolved triples.
+        let full = Hdt::read(BufReader::new(File::open(SNIKMETA).unwrap())).unwrap();
+        let expected: BTreeSet<[String; 3]> =
+            full.triples_all().map(|[s, p, o]| [s.to_string(), p.to_string(), o.to_string()]).collect();
+
+        // Decode-only path: stream IDs, resolve through the dictionary, no indexes built.
+        let (dict, stream) = Hdt::triples_streaming(BufReader::new(File::open(SNIKMETA).unwrap())).unwrap();
+        let got: BTreeSet<[String; 3]> = stream
+            .map(|[s, p, o]| {
+                [
+                    dict.id_to_string(s, IdKind::Subject).unwrap(),
+                    dict.id_to_string(p, IdKind::Predicate).unwrap(),
+                    dict.id_to_string(o, IdKind::Object).unwrap(),
+                ]
+            })
+            .collect();
+
+        assert!(!expected.is_empty(), "fixture must contain triples");
+        assert_eq!(expected, got, "decode-only stream must equal the full read path");
+    }
+}


### PR DESCRIPTION
> 🤖 This PR was opened by an **autonomous agent** (a SPARQ agent) operating on **@jeswr**'s behalf.

## ⚠️ NOT yet ready for maintainer review

This is a **draft** pending **@jeswr**'s own review first. Please do not review/merge yet — @jeswr will mark it ready once he has checked it. Opening it as a draft so the change is visible and reviewable on his timeline.

## Why

`hdt` is used (via a small wrapper) inside [`sparq`](https://github.com/jeswr/sparq), which currently maintains its **own vendored decoder** purely to read every triple once on a bulk import without paying for query-index construction. The goal of this PR is to provide that capability upstream so the downstream wrapper can **delete its vendored decoder and call `hdt` directly** instead.

`Hdt::read` builds the full `TriplesBitmap` query machinery via `TriplesBitmap::new`: a wavelet matrix over `sequence_y`, a per-object `Vec<Vec<u32>>`, a `sort_by_cached_key`, and the object–predicate index (a compact vector + a rank/select bitmap). All of that exists to serve triple-pattern / object / predicate **queries**. A consumer doing a one-shot bulk read of every triple (e.g. importing into another store, or computing a checksum) issues none of those queries, so the entire index is constructed and then immediately dropped — a large, cache-hostile cost on ingest.

## What

Adds a decode-only entry point:

```rust
impl Hdt {
    pub fn triples_streaming<R: BufRead>(reader: R)
        -> io::Result<(FourSectDict, TripleIdStreamingIter)>;
}
```

It reads the same on-disk sections the full path reads (global control info + header, the four-section dictionary, then the triples section's `bitmap_y` / `bitmap_z` / `sequence_y` / `sequence_z`) and returns the validated dictionary plus an iterator that yields `[s, p, o]` dictionary IDs in **SPO order** — **without** calling `TriplesBitmap::new`.

## How

- New module `src/triples_streaming.rs` (one `pub mod` line in `lib.rs`).
- The iterator walk is the same one `SubjectIter` performs over the built structure, but reads the predicate from `sequence_y` and the run-end flags from the two bitmaps directly (`Bitmap::at_last_sibling`), so no wavelet matrix / OP-index is built.
- Reuses the existing public section readers (`ControlInfo::read`, `Header::read`, `FourSectDict::read` + `validate`, `Bitmap::read`, `Sequence::read`) — every on-disk quirk and CRC check is handled by your existing code; only `TriplesBitmap::new` is skipped.
- Only the supported `triplesBitmap` / SPO (order 1) case is accepted, matching the full read path; everything else is a clear `InvalidData` error.

## Testing

- A **differential** unit test (`streaming_matches_full_read`) asserts the decode-only stream resolves to exactly the same triple set — as term strings via `FourSectDict::id_to_string` — as the full `Hdt::read` path on the `snikmeta` fixture.
- A runnable doctest on `triples_streaming`.
- `cargo build`, `cargo test --lib` (18/18 pass), `cargo clippy --lib` (clean under the crate's `pedantic` + `missing_const_for_fn` posture), and `cargo fmt` all pass in the fork.

Happy to adjust the naming, the return shape (e.g. yield term strings directly, or expose it as a method on a partially-read `Hdt`), or split/relocate the module however you prefer — flagging the shape as the main open design question.
