### PR TITLE
chore: Bump QWT to 0.4.0 since 0.3.5 was yanked

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ fs-err = { version = "3.1.0", optional = true }
 bitset-core = { version = "0.1.1", optional = true }
 oxttl = { version = "0.2.1", optional = true }
 lasso = { version = "0.7.3", features = ["multi-threaded"], optional = true }
-qwt = "0.3.5"
+qwt = "0.4.0"
 
 [features]
 default = ["sophia"]


### PR DESCRIPTION
Fixes the build:

```
error: failed to select a version for the requirement `qwt = "^0.3.5"`
  version 0.3.5 is yanked
location searched: crates.io index
required by package `hdt v0.7.1`
```

<img width="722" height="384" alt="Screenshot 2026-06-19 at 18 13 50" src="https://github.com/user-attachments/assets/a2e48d5a-3e44-4cea-93bf-010b54a3e9ba" />
